### PR TITLE
Bugfix/firmare updater issue 009

### DIFF
--- a/python/bin/RE1_firmware_updater.py
+++ b/python/bin/RE1_firmware_updater.py
@@ -146,7 +146,7 @@ class FirmwareRepo():
 
 
     def pretty_print_available_versions(self):
-        click.secho('######### Currently Available Versions of Stretch Firmware on Master Branch ##########',fg="green", bold=True)
+        click.secho('######### Currently Available Versions of Stretch Firmware on GitHub ##########',fg="green", bold=True)
         for device_name in self.versions.keys():
             print('---- %s ----'%device_name.upper())
             for v in self.versions[device_name]:
@@ -471,7 +471,7 @@ class FirmwareUpdater():
                 if device_name=='hello-motor-arm' or device_name=='hello-motor-lift' or device_name=='hello-motor-right-wheel' or device_name=='hello-motor-left-wheel':
                     motor = stretch_body.stepper.Stepper('/dev/' + device_name)
                     motor.startup()
-                    if False:#not motor.hw_valid:
+                    if not motor.hw_valid:
                         click.secho('Failed to startup stepper %s'%device_name,fg="red", bold=True)
                     else:
                         print('Reading calibration data from YAML...')

--- a/python/bin/RE1_firmware_updater.py
+++ b/python/bin/RE1_firmware_updater.py
@@ -146,7 +146,7 @@ class FirmwareRepo():
 
 
     def pretty_print_available_versions(self):
-        click.secho('######### Currently Available Versions of Stretch Firmware on GitHub ##########',fg="green", bold=True)
+        click.secho('######### Currently Available Versions of Stretch Firmware on Master Branch ##########',fg="green", bold=True)
         for device_name in self.versions.keys():
             print('---- %s ----'%device_name.upper())
             for v in self.versions[device_name]:
@@ -471,7 +471,7 @@ class FirmwareUpdater():
                 if device_name=='hello-motor-arm' or device_name=='hello-motor-lift' or device_name=='hello-motor-right-wheel' or device_name=='hello-motor-left-wheel':
                     motor = stretch_body.stepper.Stepper('/dev/' + device_name)
                     motor.startup()
-                    if not motor.hw_valid:
+                    if False:#not motor.hw_valid:
                         click.secho('Failed to startup stepper %s'%device_name,fg="red", bold=True)
                     else:
                         print('Reading calibration data from YAML...')

--- a/python/bin/RE1_usb_reset.py
+++ b/python/bin/RE1_usb_reset.py
@@ -1,39 +1,75 @@
 #!/usr/bin/env python
+#import usb.core
+
 import os
 import sys
 from subprocess import Popen, PIPE
 import fcntl
 import subprocess
-import usb.core
 
 
 def reset_arduino_usb():
-    devs=[]
-    all = usb.core.find(find_all=True)
-    for dev in all:
-        if dev.idVendor==0x2341 and dev.idProduct==0x804d:
-            devs.append(dev)
-    print('Found %d Arduino devices'%len(devs))
-    for d in devs:
-        print('Resetting Arduino. Bus: %s | Device  %s ' % (d.bus, d.address))
+    USBDEVFS_RESET = 21780
+    lsusb_out = Popen("lsusb | grep -i %s" % 'Arduino', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                      close_fds=True).stdout.read().strip().split()
+    while len(lsusb_out):
+        bus = lsusb_out[1]
+        device = lsusb_out[3][:-1]
         try:
-            d.reset()
-        except usb.core.USBError:
-            print('Error in resetting device')
+            print('Resetting Arduino. Bus: %s | Device  %s '%(bus, device))
+            f = open("/dev/bus/usb/%s/%s" % (bus, device), 'w', os.O_WRONLY)
+            fcntl.ioctl(f, USBDEVFS_RESET, 0)
+        except Exception as msg:
+            print("failed to reset device: %s" % msg)
+        lsusb_out = lsusb_out[8:]
 
 def reset_FTDI_usb():
-    devs=[]
-    all = usb.core.find(find_all=True)
-    for dev in all:
-        if dev.idVendor==0x0403 and dev.idProduct==0x6001:
-            devs.append(dev)
-    print('Found %d FTDI devices'%len(devs))
-    for d in devs:
-        print('Resetting FTDI. Bus: %s | Device  %s ' % (d.bus, d.address))
+    USBDEVFS_RESET = 21780
+    lsusb_out = Popen("lsusb | grep -i %s"%'Future', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip().split()
+    while len(lsusb_out):
+        bus = lsusb_out[1]
+        device = lsusb_out[3][:-1]
         try:
-            d.reset()
-        except usb.core.USBError:
-            print('Error in resetting device')
+            print('Resetting FTDI. Bus: %s | Device  %s '%(bus, device))
+            f = open("/dev/bus/usb/%s/%s" % (bus, device), 'w', os.O_WRONLY)
+            fcntl.ioctl(f, USBDEVFS_RESET, 0)
+
+        except Exception as msg:
+            print("failed to reset device: %s"%msg)
+        lsusb_out=lsusb_out[15:]
+
+# if os.geteuid() == 0:
+#     reset_arduino_usb()
+#     reset_FTDI_usb()
+# else:
+#     subprocess.call(['sudo', 'python'] + sys.argv)  # modified
+# def reset_arduino_usb():
+#     devs=[]
+#     all = usb.core.find(find_all=True)
+#     for dev in all:
+#         if dev.idVendor==0x2341 and dev.idProduct==0x804d:
+#             devs.append(dev)
+#     print('Found %d Arduino devices'%len(devs))
+#     for d in devs:
+#         print('Resetting Arduino. Bus: %s | Device  %s ' % (d.bus, d.address))
+#         try:
+#             d.reset()
+#         except usb.core.USBError:
+#             print('Error in resetting device')
+#
+# def reset_FTDI_usb():
+#     devs=[]
+#     all = usb.core.find(find_all=True)
+#     for dev in all:
+#         if dev.idVendor==0x0403 and dev.idProduct==0x6001:
+#             devs.append(dev)
+#     print('Found %d FTDI devices'%len(devs))
+#     for d in devs:
+#         print('Resetting FTDI. Bus: %s | Device  %s ' % (d.bus, d.address))
+#         try:
+#             d.reset()
+#         except usb.core.USBError:
+#             print('Error in resetting device')
 
 if os.geteuid() == 0:
     reset_arduino_usb()


### PR DESCRIPTION
This revamps how the git repo under /tmp is managed such that it doesn't need to be cloned everytime. 

It also creates a config file under /tmp such that there are no dependencies on ~/repo/stretch_firmware.

Finally, it uses the usb.core class to reset the USB bus and introduces a sleep before the final usb_bus_reset. This allows for error free reset of the bus after stepper calibration writing.
