### PR TITLE
Bugfix/calibration flash

### DIFF
--- a/python/stretch_factory/firmware_updater.py
+++ b/python/stretch_factory/firmware_updater.py
@@ -409,11 +409,11 @@ class FirmwareUpdater():
                     print('Writing calibration data to flash...')
                     motor.write_encoder_calibration_to_flash(data)
                     print('Successful write of FLASH.')
+                    self.wait_on_device(device_name)
                     motor.board_reset()
                     motor.push_command()
                     motor.transport.ser.close()
-                    print('Resetting board')
-                    time.sleep(2.0) #Flashing causes board to reset, give time to reset
+                    time.sleep(2.0)
                     self.wait_on_device(device_name)
                     print('Successful return of device to bus.')
 


### PR DESCRIPTION
The timing of reseting the board after the calibration flash caused a crash. Determined that the stepper firmware was already resetting the board. So now wait for it to return to the bus, close the port, then reset it once more. This leaves the joint on the bus in a ready state.