### PR TITLE
Temp fix for failing DXL loggers and louder erroring on dxl jog tool

### DIFF
--- a/python/tools/RE1_dynamixel_id_change.py
+++ b/python/tools/RE1_dynamixel_id_change.py
@@ -2,6 +2,8 @@
 from future.builtins import input
 from stretch_body.dynamixel_XL430 import *
 import argparse
+import stretch_body.device
+d = stretch_body.device.Device(name='dummy_device') # to initialize logging config
 
 
 parser=argparse.ArgumentParser(description='Set the ID of a Dynamixel servo')

--- a/python/tools/RE1_dynamixel_id_scan.py
+++ b/python/tools/RE1_dynamixel_id_scan.py
@@ -2,6 +2,8 @@
 
 from stretch_body.dynamixel_XL430 import DynamixelXL430, DynamixelCommError
 import argparse
+import stretch_body.device
+d = stretch_body.device.Device(name='dummy_device') # to initialize logging config
 
 
 parser=argparse.ArgumentParser(description='Scan a dynamixel bus by ID for servos')

--- a/python/tools/RE1_dynamixel_jog.py
+++ b/python/tools/RE1_dynamixel_jog.py
@@ -4,6 +4,8 @@ from future.builtins import input
 import sys
 from stretch_body.dynamixel_XL430 import *
 import argparse
+import stretch_body.device
+d = stretch_body.device.Device(name='dummy_device') # to initialize logging config
 
 
 parser=argparse.ArgumentParser(description='Jog a Dynamixel servo from the command line')
@@ -13,12 +15,9 @@ parser.add_argument("--baud", help="Baud rate (57600, 115200, or 1000000) [57600
 args = parser.parse_args()
 
 m = DynamixelXL430(args.id, args.usb,baud=args.baud)
-m.startup()
-
-
-if not m.do_ping():
+if not m.startup() or not m.do_ping():
+    print('Failed to start servo with given usb/id/baud info')
     exit(0)
-
 
 m.disable_torque()
 #If servo somehow has wrong drive mode it may appear to not respond to vel/accel profiles

--- a/python/tools/RE1_dynamixel_reboot.py
+++ b/python/tools/RE1_dynamixel_reboot.py
@@ -2,6 +2,8 @@
 from stretch_body.dynamixel_XL430 import *
 from stretch_body.hello_utils import *
 import argparse
+import stretch_body.device
+d = stretch_body.device.Device(name='dummy_device') # to initialize logging config
 
 
 parser=argparse.ArgumentParser(description='Reboot all of the Dynamixel servos on a bus')

--- a/python/tools/RE1_dynamixel_set_baud.py
+++ b/python/tools/RE1_dynamixel_set_baud.py
@@ -2,6 +2,8 @@
 
 from stretch_body.dynamixel_XL430 import DynamixelXL430
 import argparse
+import stretch_body.device
+d = stretch_body.device.Device(name='dummy_device') # to initialize logging config
 
 
 parser=argparse.ArgumentParser(description='Change the baudrate of a servo')


### PR DESCRIPTION
This PR fixes a issue with the RE1 dynamixel tools where the loggers do not start up correct, and errors are not sent to the console. Futhermore, this PR allows the RE1_dynamixel_jog.py tool to exit with an error when it fails to start a Dxl device.