### PR TITLE
Feature/hello discover devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ pip install  hello-robot-stretch-factory
 
 The available Stretch Factory tools can be found by tab completing after typing 'REx_'. For example:
 ```bash
-REx_base_calibrate_imu_collect.py         REx_dynamixel_reboot.py                   REx_stepper_calibration_YAML_to_flash.py
-REx_base_calibrate_imu_process.py         REx_dynamixel_set_baud.py                 REx_stepper_jog.py
-REx_base_calibrate_wheel_separation.py    REx_firmware_updater.py                   REx_stepper_mechaduino_menu.py
-REx_cliff_sensor_calibrate.py             REx_gripper_calibrate.py                  REx_timestamp_manager_analyze.py
-REx_clock_manager_analyze.py              REx_head_calibrate_pan.py                 REx_usb_reset.py
-REx_dynamixel_id_change.py                REx_hello_dynamixel_jog.py                REx_wacc_calibrate.py
-REx_dynamixel_id_scan.py                  REx_stepper_calibration_flash_to_YAML.py  
-REx_dynamixel_jog.py                      REx_stepper_calibration_run.py            
+REx_base_calibrate_imu_collect.py         REx_D435i_check.py                        REx_dynamixel_set_baud.py                 REx_stepper_calibration_run.py            REx_usb_reset.py
+REx_base_calibrate_imu_process.py         REx_discover_hello_devices.py             REx_firmware_updater.py                   REx_stepper_calibration_YAML_to_flash.py  REx_wacc_calibrate.py
+REx_base_calibrate_wheel_separation.py    REx_dynamixel_id_change.py                REx_gamepad_configure.py                  REx_stepper_ctrl_tuning.py                
+REx_calibrate_guarded_contact.py          REx_dynamixel_id_scan.py                  REx_gripper_calibrate.py                  REx_stepper_gains.py                      
+REx_calibrate_range.py                    REx_dynamixel_jog.py                      REx_hello_dynamixel_jog.py                REx_stepper_jog.py                        
+REx_cliff_sensor_calibrate.py             REx_dynamixel_reboot.py                   REx_stepper_calibration_flash_to_YAML.py  REx_stepper_mechaduino_menu.py    
 
 ```
 For useage of these tools, try for example:

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ stretch_scripts=[f for f in ex_scripts if isfile(f)]
 
 setuptools.setup(
     name="hello_robot_stretch_factory",
-    version="0.3.9",
+    version="0.3.11",
     author="Hello Robot Inc.",
     author_email="support@hello-robot.com",
     description="Stretch Factory Tools",

--- a/python/stretch_factory/hello_device_utils.py
+++ b/python/stretch_factory/hello_device_utils.py
@@ -447,3 +447,42 @@ def assign_dynamixel_to_robot(device_name, robot_sn=None):
         add_ftdi_udev_line(device_name,sn,fleet_dir)
         return  {'success': 1, 'sn': sn}
     return  {'success': 0, 'sn':None}
+
+def extract_udevadm_info(usb_port, ID_NAME=None):
+    """
+    Extracts usb device attributes with the given attribute ID_NAME
+
+    example ID_NAME:
+    ID_SERIAL_SHORT
+    ID_MODEL
+    DEVPATH
+    ID_VENDOR_FROM_DATABASE
+    ID_VENDOR
+    """
+    value = None
+    dname = bytes(usb_port[5:], 'utf-8')
+    out = exec_process([b'udevadm', b'info', b'-n', dname], True)
+    if ID_NAME is None:
+        value = out.decode(encoding='UTF-8')
+    else:
+        for a in out.split(b'\n'):
+            a = a.decode(encoding='UTF-8')
+            if "{}=".format(ID_NAME) in a:
+                value = a.split('=')[-1]
+    return value
+
+def find_tty_devices():
+    devices_dict = {}
+    ttyUSB_dev_list = glob.glob('/dev/ttyUSB*')
+    ttyACM_dev_list = glob.glob('/dev/ttyACM*')
+    for d in ttyACM_dev_list:
+        devices_dict[d] = {"serial": extract_udevadm_info(d, 'ID_SERIAL_SHORT'),
+                           "vendor": extract_udevadm_info(d, 'ID_VENDOR'),
+                           "model": extract_udevadm_info(d, 'ID_MODEL'),
+                           "path": extract_udevadm_info(d, 'DEVPATH')}
+    for d in ttyUSB_dev_list:
+        devices_dict[d] = {"serial": extract_udevadm_info(d, 'ID_SERIAL_SHORT'),
+                           "vendor": extract_udevadm_info(d, 'ID_VENDOR'),
+                           "model": extract_udevadm_info(d, 'ID_MODEL'),
+                           "path": extract_udevadm_info(d, 'DEVPATH')}
+    return devices_dict

--- a/python/stretch_factory/hello_device_utils.py
+++ b/python/stretch_factory/hello_device_utils.py
@@ -523,7 +523,7 @@ def extract_udevadm_info(usb_port, ID_NAME=None):
     """
     value = None
     dname = bytes(usb_port[5:], 'utf-8')
-    out = hdu.exec_process([b'udevadm', b'info', b'-n', dname], True)
+    out = exec_process([b'udevadm', b'info', b'-n', dname], True)
     if ID_NAME is None:
         value = out.decode(encoding='UTF-8')
     else:

--- a/python/stretch_factory/hello_device_utils.py
+++ b/python/stretch_factory/hello_device_utils.py
@@ -7,12 +7,13 @@ from subprocess import Popen, PIPE
 import fcntl
 import subprocess
 import sys
-
+import glob
 from subprocess import Popen, PIPE
 import usb.core
 import stretch_body.hello_utils as hello_utils
 import stretch_body.robot_params
 import stretch_body.device
+
 
 # ###################################
 class stream_tee(object):
@@ -38,33 +39,40 @@ class stream_tee(object):
         # Emit method call to stdout (stream 1)
         callable1 = getattr(self.stream1, self.__missing_method_name)
         return callable1(*args, **kwargs)
+
+
 # ###################################
 def check_internet():
     url = "http://github.com"
     timeout = 10
     for i in range(10):
-        print('Attempting to reach internet. Try %d of 10'%(i+1))
+        print('Attempting to reach internet. Try %d of 10' % (i + 1))
         try:
             requests.get(url, timeout=timeout)
             print("Connected to the GitHub")
-            return {'success':1}
+            return {'success': 1}
         except (requests.ConnectionError, requests.Timeout) as exception:
             print("Failed to establish internet connection.")
             time.sleep(0.5)
-    return {'success':0}
+    return {'success': 0}
+
+
 # ###################################
 def check_arduino_cli_install():
     """
     Return true if the arduino-cli is available
     """
-    res=Popen('arduino-cli version', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read()[:11]
-    if not(res==b'arduino-cli'):
+    res = Popen('arduino-cli version', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read()[
+          :11]
+    if not (res == b'arduino-cli'):
         print('WARNING:---------------------------------------------------------------------------------')
         print('WARNING: Tool arduino_cli not installed. See stretch_install_dev.sh (Stretch Install repo)')
         print('WARNING:---------------------------------------------------------------------------------')
         print('')
         return False
     return True
+
+
 # ###################################
 def exec_process(cmdline, silent, input=None, **kwargs):
     """Execute a subprocess and returns the returncode, stdout buffer and stderr buffer.
@@ -82,45 +90,53 @@ def exec_process(cmdline, silent, input=None, **kwargs):
         else:
             raise
     if returncode != 0:
-        raise RuntimeError('Got return value %d while executing "%s", stderr output was:\n%s' % (returncode, " ".join(cmdline), stderr.rstrip(b"\n")))
+        raise RuntimeError('Got return value %d while executing "%s", stderr output was:\n%s' % (
+        returncode, " ".join(cmdline), stderr.rstrip(b"\n")))
     return stdout
+
 
 # ###################################
 def get_device_ttyACMx(device):
-    #Return the ACMx of a symlinked device, eg 'ttyACM0' given /dev/hello-motor-arm
+    # Return the ACMx of a symlinked device, eg 'ttyACM0' given /dev/hello-motor-arm
     try:
-        ACMx = Popen("ls -l %s"%device, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip().split()[-1]
-        ACMx=ACMx.decode("utf-8")
+        ACMx = Popen("ls -l %s" % device, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                     close_fds=True).stdout.read().strip().split()[-1]
+        ACMx = ACMx.decode("utf-8")
         return ACMx
     except IndexError:
         return None
 
+
 def get_all_ttyACMx():
-    #Return list of ACMx names eg ['ttyACM0','ttyACM1']
-    ACMx_all = Popen("ls -l /dev/ttyACM*", shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip().split()
-    ret=[]
+    # Return list of ACMx names eg ['ttyACM0','ttyACM1']
+    ACMx_all = Popen("ls -l /dev/ttyACM*", shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                     close_fds=True).stdout.read().strip().split()
+    ret = []
     for line in ACMx_all:
-        l=line.decode("utf-8")
-        if l.find('ttyACM')!=-1:
+        l = line.decode("utf-8")
+        if l.find('ttyACM') != -1:
             ret.append(l[5:])
     return ret
 
 
-
 def is_device_present(device):
     try:
-        exec_process(['ls',device],True)
+        exec_process(['ls', device], True)
         return True
     except RuntimeError as e:
         return False
 
+
 def find_steppers_on_bus():
-    s=[]
-    device_names=['/dev/hello-motor-arm', '/dev/hello-motor-lift', '/dev/hello-motor-right-wheel', '/dev/hello-motor-left-wheel']
+    s = []
+    device_names = ['/dev/hello-motor-arm', '/dev/hello-motor-lift', '/dev/hello-motor-right-wheel',
+                    '/dev/hello-motor-left-wheel']
     for d in device_names:
         if is_device_present(d):
             s.append(d)
     return s
+
+
 # ###################################
 def find_arduinos():
     devs = []
@@ -130,6 +146,7 @@ def find_arduinos():
             devs.append(dev)
     return devs
 
+
 def find_ftdis():
     devs = []
     all = usb.core.find(find_all=True)
@@ -138,9 +155,11 @@ def find_ftdis():
             devs.append(dev)
     return devs
 
+
 # ###################################
 def get_dmesg():
     return exec_process(['sudo', 'dmesg', '-c'], True)
+
 
 def find_arduino():
     """
@@ -149,49 +168,55 @@ def find_arduino():
     dmesg_data = get_dmesg()
     lines = dmesg_data.split(b'\n')
     for idx in range(len(lines)):
-        if lines[idx].find(b'Product: Hello')>0:
-            board=lines[idx][lines[idx].find(b'Product: ')+9:]
-            idx=min(idx+2,len(lines)-1)
-            if lines[idx].find(b'SerialNumber') >0:
-                sn=lines[idx][lines[idx].find(b'SerialNumber')+14:]
-                if lines[idx].find(b'SerialNumber') >0:
-                    sn=lines[idx][lines[idx].find(b'SerialNumber')+14:]
-                    idx=min(idx+1,len(lines)-1)
+        if lines[idx].find(b'Product: Hello') > 0:
+            board = lines[idx][lines[idx].find(b'Product: ') + 9:]
+            idx = min(idx + 2, len(lines) - 1)
+            if lines[idx].find(b'SerialNumber') > 0:
+                sn = lines[idx][lines[idx].find(b'SerialNumber') + 14:]
+                if lines[idx].find(b'SerialNumber') > 0:
+                    sn = lines[idx][lines[idx].find(b'SerialNumber') + 14:]
+                    idx = min(idx + 1, len(lines) - 1)
                     if lines[idx].find(b'ttyACM') > 0:
-                        port = b'/dev/'+lines[idx][lines[idx].find(b'ttyACM'):lines[idx].find(b'ttyACM')+7] #only ttyACM0-9
+                        port = b'/dev/' + lines[idx][
+                                          lines[idx].find(b'ttyACM'):lines[idx].find(b'ttyACM') + 7]  # only ttyACM0-9
                         if (is_device_present(port)):
                             print('---------------------------')
-                            print('Found board %s with SerialNumber %s on port %s'%(board,sn,port))
-                            return {'board':board,'serial':sn,'port':port}
+                            print('Found board %s with SerialNumber %s on port %s' % (board, sn, port))
+                            return {'board': board, 'serial': sn, 'port': port}
     print('No Arduino device device found')
-    return {'board':None,'serial':None,'port':None}
+    return {'board': None, 'serial': None, 'port': None}
+
 
 def find_ftdi_sn():
     try:
-        x=exec_process([b'sudo',b'lsusb', b'-d', b'0403:6001',b'-v'], True).split(b'\n')
+        x = exec_process([b'sudo', b'lsusb', b'-d', b'0403:6001', b'-v'], True).split(b'\n')
         for ln in x:
-            if ln.find(b'iSerial')>=0:
-                sn=ln.split(b' ')[-1]
+            if ln.find(b'iSerial') >= 0:
+                sn = ln.split(b' ')[-1]
                 return sn
     except RuntimeError:
         print('FTDI device not found')
         return None
 
+
 def find_shoulder_hub():
-    lsusb_out = Popen("lsusb | grep '1a40:0101'", shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip().split()
-    #Note: User periphs using Terminus may ID false positive
+    lsusb_out = Popen("lsusb | grep '1a40:0101'", shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                      close_fds=True).stdout.read().strip().split()
+    # Note: User periphs using Terminus may ID false positive
     if len(lsusb_out):
         bus = lsusb_out[1]
         device = lsusb_out[3][:-1]
-        port= "/dev/bus/usb/%s/%s" % (bus, device)
-        print('Found shoulder hub IC on bus at %s'%port)
-        return {'success':1}
+        port = "/dev/bus/usb/%s/%s" % (bus, device)
+        print('Found shoulder hub IC on bus at %s' % port)
+        return {'success': 1}
     else:
         print('Terminus USB2 hub not found')
-        return {'success':0}
+        return {'success': 0}
+
 
 def find_ftdi_port():
-    lsusb_out = Popen("lsusb | grep -i %s"%'Future', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip().split()
+    lsusb_out = Popen("lsusb | grep -i %s" % 'Future', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                      close_fds=True).stdout.read().strip().split()
     if len(lsusb_out):
         bus = lsusb_out[1]
         device = lsusb_out[3][:-1]
@@ -199,44 +224,51 @@ def find_ftdi_port():
     else:
         print('FTDI port not found')
         return None
+
+
 # ###################################
-def compile_arduino_firmware(sketch_name,repo_path):
+def compile_arduino_firmware(sketch_name, repo_path):
     """
     :param sketch_name: eg 'hello_stepper'
     :return T if success:
     """
-    compile_command = 'arduino-cli compile --fqbn hello-robot:samd:%s %s/arduino/%s' % (sketch_name, repo_path, sketch_name)
+    compile_command = 'arduino-cli compile --fqbn hello-robot:samd:%s %s/arduino/%s' % (
+    sketch_name, repo_path, sketch_name)
     print(compile_command)
     c = Popen(compile_command, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
-    return c.find(b'Sketch uses')>-1
+    return c.find(b'Sketch uses') > -1
 
-def burn_arduino_firmware(port, sketch_name,repo_path):
+
+def burn_arduino_firmware(port, sketch_name, repo_path):
     print('-------- Flashing firmware %s | %s ------------' % (port, sketch_name))
-    port_name = Popen("ls -l " + port, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip().split()[-1]
-    port_name=port_name.decode("utf-8")
+    port_name = Popen("ls -l " + port, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                      close_fds=True).stdout.read().strip().split()[-1]
+    port_name = port_name.decode("utf-8")
     if port_name is not None:
-        upload_command = 'arduino-cli upload -p %s --fqbn hello-robot:samd:%s %s/arduino/%s' % (port_name, sketch_name,repo_path, sketch_name)
-        print('Running: %s'%upload_command)
+        upload_command = 'arduino-cli upload -p %s --fqbn hello-robot:samd:%s %s/arduino/%s' % (
+        port_name, sketch_name, repo_path, sketch_name)
+        print('Running: %s' % upload_command)
         u = Popen(upload_command, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
         uu = u.split(b'\n')
-        #Pretty print the result
+        # Pretty print the result
         for l in uu:
-            k=l.split(b'\r')
-            if len(k)==1:
+            k = l.split(b'\r')
+            if len(k) == 1:
                 print(k[0].decode('utf-8'))
             else:
                 for m in k:
                     print(m.decode('utf-8'))
         print('################')
-        success=uu[-1]==b'CPU reset.'
+        success = uu[-1] == b'CPU reset.'
         if not success:
-            print('Firmware flash. Failed to upload to %s'% ( port))
+            print('Firmware flash. Failed to upload to %s' % (port))
         else:
             print('Success in firmware flash')
         return success
     else:
-        print('Firmware flash. Failed to find device %s' % ( port))
+        print('Firmware flash. Failed to find device %s' % (port))
         return False
+
 
 def burn_bootloader(sketch):
     print('-------- Burning bootlader ------------')
@@ -244,54 +276,57 @@ def burn_bootloader(sketch):
     cmdl = ['arduino-cli', 'burn-bootloader', '-b', 'hello-robot:samd:%s' % sketch, '-P', 'sam_ice']
     print(cmd)
     u = subprocess.call(cmdl)
-    return u==0
+    return u == 0
+
 
 # ##################################
 
 def reset_arduino_usb():
     USBDEVFS_RESET = 21780
-    lsusb_out = Popen("lsusb | grep -i %s"%'Arduino', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip().split()
+    lsusb_out = Popen("lsusb | grep -i %s" % 'Arduino', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                      close_fds=True).stdout.read().strip().split()
     while len(lsusb_out):
         bus = lsusb_out[1]
         device = lsusb_out[3][:-1]
         try:
-            print('Resetting Arduino. Bus:',bus, 'Device: ',device)
+            print('Resetting Arduino. Bus:', bus, 'Device: ', device)
             f = open("/dev/bus/usb/%s/%s" % (bus, device), 'w', os.O_WRONLY)
             fcntl.ioctl(f, USBDEVFS_RESET, 0)
         except Exception as msg:
-            print("failed to reset device: %s"%msg)
-        lsusb_out=lsusb_out[8:]
+            print("failed to reset device: %s" % msg)
+        lsusb_out = lsusb_out[8:]
+
 
 # ##############################################################
 
-def run_firmware_flash(port,sketch,repo_path=''):
-    #Return board serial # / success
-    print('### Running Firmware Flash on port %s and sketch %s'%(port,sketch))
+def run_firmware_flash(port, sketch, repo_path=''):
+    # Return board serial # / success
+    print('### Running Firmware Flash on port %s and sketch %s' % (port, sketch))
     print('###################################################################')
     if burn_bootloader(sketch):
         print('SUCCESS: Burned bootloader')
     else:
         print('FAIL: Could not burn bootlaoder')
-        return  {'success':0,'sn':None}
+        return {'success': 0, 'sn': None}
     time.sleep(2.0)
     if is_device_present(port):
-        print('SUCCESS: Found PCBA on %s'%port)
+        print('SUCCESS: Found PCBA on %s' % port)
     else:
-        print('FAIL: Did not find PCBA on %s'%port)
-        return  {'success':0,'sn':None}
+        print('FAIL: Did not find PCBA on %s' % port)
+        return {'success': 0, 'sn': None}
 
-    if compile_arduino_firmware(sketch,repo_path):
+    if compile_arduino_firmware(sketch, repo_path):
         print('SUCCESS: Found compiled sketch %s' % sketch)
     else:
         print('FAIL: Could not compile sketch %s' % sketch)
-        return  {'success':0,'sn':None}
+        return {'success': 0, 'sn': None}
 
     get_dmesg()
-    if burn_arduino_firmware(port,sketch,repo_path):
+    if burn_arduino_firmware(port, sketch, repo_path):
         print('SUCCESS: Flashed sketch %s' % sketch)
     else:
         print('FAIL: Could not flash sketch %s' % sketch)
-        return  {'success':0,'sn':None}
+        return {'success': 0, 'sn': None}
     time.sleep(2.0)
     x = find_arduino()
     if x['serial'] is not None:
@@ -305,19 +340,20 @@ def run_firmware_flash(port,sketch,repo_path=''):
 
 
 # ######################## RDK Tools ##########################################
-def modify_bashrc(env_var,env_var_val):
-    f=open(os.environ['HOME']+'/.bashrc','r')
-    x=f.readlines()
-    x_out=''
+def modify_bashrc(env_var, env_var_val):
+    f = open(os.environ['HOME'] + '/.bashrc', 'r')
+    x = f.readlines()
+    x_out = ''
     for xx in x:
-        if xx.find(env_var)>0:
-            x_out=x_out+'export '+env_var+'='+env_var_val+'\n'
+        if xx.find(env_var) > 0:
+            x_out = x_out + 'export ' + env_var + '=' + env_var_val + '\n'
         else:
-            x_out=x_out+xx
+            x_out = x_out + xx
     f.close()
-    f=open(os.environ['HOME']+'/.bashrc','w')
+    f = open(os.environ['HOME'] + '/.bashrc', 'w')
     f.write(x_out)
     f.close()
+
 
 def add_arduino_udev_line_etc(device_name, serial_no):
     f = open('/etc/udev/rules.d/95-hello-arduino.rules', 'r')
@@ -336,20 +372,21 @@ def add_arduino_udev_line_etc(device_name, serial_no):
         print('Creating new entry...')
         x_out = x_out + uline
     f.close()
-    f = open( '/tmp/95-hello-arduino.rules', 'w')
+    f = open('/tmp/95-hello-arduino.rules', 'w')
     f.write(x_out)
     f.close()
     os.system('sudo cp /tmp/95-hello-arduino.rules /etc/udev/rules.d')
 
-def add_arduino_udev_line(device_name, serial_no,fleet_dir):
-    f = open(fleet_dir+'udev/95-hello-arduino.rules', 'r')
+
+def add_arduino_udev_line(device_name, serial_no, fleet_dir):
+    f = open(fleet_dir + 'udev/95-hello-arduino.rules', 'r')
     x = f.readlines()
     x_out = ''
-    overwrite=False
-    uline = 'KERNEL=="ttyACM*", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="804d",MODE:="0666", ATTRS{serial}=="'+serial_no + '", SYMLINK+="'+device_name+'", ENV{ID_MM_DEVICE_IGNORE}="1"\n'
+    overwrite = False
+    uline = 'KERNEL=="ttyACM*", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="804d",MODE:="0666", ATTRS{serial}=="' + serial_no + '", SYMLINK+="' + device_name + '", ENV{ID_MM_DEVICE_IGNORE}="1"\n'
     for xx in x:
-        if xx.find(device_name) > 0 and xx[0]!='#':
-            overwrite=True
+        if xx.find(device_name) > 0 and xx[0] != '#':
+            overwrite = True
             x_out = x_out + uline
             print('Overwriting existing entry...')
         else:
@@ -358,20 +395,21 @@ def add_arduino_udev_line(device_name, serial_no,fleet_dir):
         print('Creating new entry...')
         x_out = x_out + uline
     f.close()
-    f = open(fleet_dir+'udev/95-hello-arduino.rules', 'w')
+    f = open(fleet_dir + 'udev/95-hello-arduino.rules', 'w')
     f.write(x_out)
     f.close()
 
-def add_ftdi_udev_line(device_name, serial_no,fleet_dir):
-    f = open(fleet_dir+'udev/99-hello-dynamixel.rules', 'r')
+
+def add_ftdi_udev_line(device_name, serial_no, fleet_dir):
+    f = open(fleet_dir + 'udev/99-hello-dynamixel.rules', 'r')
     x = f.readlines()
     x_out = ''
-    overwrite=False
-    uline = 'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTR{device/latency_timer}="1", ATTRS{serial}=="'+serial_no+'", SYMLINK+="'+device_name+'"'
+    overwrite = False
+    uline = 'SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTR{device/latency_timer}="1", ATTRS{serial}=="' + serial_no + '", SYMLINK+="' + device_name + '"'
     for xx in x:
-        if xx.find(device_name) > 0 and xx[0]!='#':
-            overwrite=True
-            x_out = x_out + uline +'\n'
+        if xx.find(device_name) > 0 and xx[0] != '#':
+            overwrite = True
+            x_out = x_out + uline + '\n'
             print('Overwriting existing entry...')
         else:
             x_out = x_out + xx
@@ -379,32 +417,34 @@ def add_ftdi_udev_line(device_name, serial_no,fleet_dir):
         print('Creating new entry...')
         x_out = x_out + uline + '\n'
     f.close()
-    f = open(fleet_dir+'udev/99-hello-dynamixel.rules', 'w')
+    f = open(fleet_dir + 'udev/99-hello-dynamixel.rules', 'w')
     f.write(x_out)
     f.close()
 
+
 def get_serial_nos_from_udev(udev_file_full_path, device_name):
-    sns=[]
+    sns = []
     try:
         f = open(udev_file_full_path, 'r')
         x = f.readlines()
         f.close()
-        lines=[]
+        lines = []
         for xx in x:
-            if xx.find(device_name) > 0 and xx[0]!='#':
+            if xx.find(device_name) > 0 and xx[0] != '#':
                 lines.append(xx)
         for l in lines:
-            ll=l.split(',')
+            ll = l.split(',')
             for q in ll:
-                if q.find('serial')>-1:
-                    s=q[q.find('"')+1:q.rfind('"')]
-                    if len(s)==8 or len(s)==32: #FTDI or Arduino
+                if q.find('serial') > -1:
+                    s = q[q.find('"') + 1:q.rfind('"')]
+                    if len(s) == 8 or len(s) == 32:  # FTDI or Arduino
                         sns.append(s)
     except:
         pass
     return sns
 
-def assign_arduino_to_robot(device_name,is_stepper=False,robot_sn=None):
+
+def assign_arduino_to_robot(device_name, is_stepper=False, robot_sn=None):
     """
     This expects only a single arduino device on the bus
     Tie the uC serial number to device_name under udev
@@ -412,66 +452,48 @@ def assign_arduino_to_robot(device_name,is_stepper=False,robot_sn=None):
     The YAML writing requres the HELLO_FLEET_ID to be set in advance
     """
     if robot_sn is None:
-       fleet_dir=hello_utils.get_fleet_directory()
+        fleet_dir = hello_utils.get_fleet_directory()
     else:
-        fleet_dir=os.environ['HELLO_FLEET_PATH']+'/'+robot_sn+'/'
+        fleet_dir = os.environ['HELLO_FLEET_PATH'] + '/' + robot_sn + '/'
     a = find_arduinos()
     if len(a) != 1:
         print('Error: Only one Arduino should be on the bus')
     else:
-        sn=str(a[0].serial_number)
-        add_arduino_udev_line(device_name,sn,fleet_dir)
+        sn = str(a[0].serial_number)
+        add_arduino_udev_line(device_name, sn, fleet_dir)
         if is_stepper:
-            print('Setting serial number in YAML for %s to %s'%(device_name,sn))
+            print('Setting serial number in YAML for %s to %s' % (device_name, sn))
             d = stretch_body.device.Device(req_params=False)
-            d.write_configuration_param_to_YAML(device_name+'.serial_no', sn,fleet_dir=fleet_dir)
-        return  {'success': 1, 'sn': sn}
-    return  {'success': 0, 'sn':None}
+            d.write_configuration_param_to_YAML(device_name + '.serial_no', sn, fleet_dir=fleet_dir)
+        return {'success': 1, 'sn': sn}
+    return {'success': 0, 'sn': None}
+
 
 def assign_dynamixel_to_robot(device_name, robot_sn=None):
     """
     This expects only a single FTDI device on the bus
     Tie the FTDI serial number to device_name under udev
     """
-    print('A',hello_utils.get_fleet_directory())
-    print('B',os.environ['HELLO_FLEET_PATH'],robot_sn)
+    print('A', hello_utils.get_fleet_directory())
+    print('B', os.environ['HELLO_FLEET_PATH'], robot_sn)
     if robot_sn is None:
-        fleet_dir=hello_utils.get_fleet_directory()
+        fleet_dir = hello_utils.get_fleet_directory()
     else:
-        fleet_dir=os.environ['HELLO_FLEET_PATH']+'/'+robot_sn+'/'
-    f=find_ftdis()
+        fleet_dir = os.environ['HELLO_FLEET_PATH'] + '/' + robot_sn + '/'
+    f = find_ftdis()
     if len(f) != 1:
         print('Error: Only one FTDI should be on the bus')
     else:
-        sn=f[0].serial_number
-        add_ftdi_udev_line(device_name,sn,fleet_dir)
-        return  {'success': 1, 'sn': sn}
-    return  {'success': 0, 'sn':None}
+        sn = f[0].serial_number
+        add_ftdi_udev_line(device_name, sn, fleet_dir)
+        return {'success': 1, 'sn': sn}
+    return {'success': 0, 'sn': None}
 
-def extract_udevadm_info(usb_port, ID_NAME=None):
-    """
-    Extracts usb device attributes with the given attribute ID_NAME
-
-    example ID_NAME:
-    ID_SERIAL_SHORT
-    ID_MODEL
-    DEVPATH
-    ID_VENDOR_FROM_DATABASE
-    ID_VENDOR
-    """
-    value = None
-    dname = bytes(usb_port[5:], 'utf-8')
-    out = exec_process([b'udevadm', b'info', b'-n', dname], True)
-    if ID_NAME is None:
-        value = out.decode(encoding='UTF-8')
-    else:
-        for a in out.split(b'\n'):
-            a = a.decode(encoding='UTF-8')
-            if "{}=".format(ID_NAME) in a:
-                value = a.split('=')[-1]
-    return value
 
 def find_tty_devices():
+    """
+    Returns a dictionary of USB device details of tty class in the ttyUSB* and ttyACM* namespace.
+    """
     devices_dict = {}
     ttyUSB_dev_list = glob.glob('/dev/ttyUSB*')
     ttyACM_dev_list = glob.glob('/dev/ttyACM*')
@@ -486,3 +508,27 @@ def find_tty_devices():
                            "model": extract_udevadm_info(d, 'ID_MODEL'),
                            "path": extract_udevadm_info(d, 'DEVPATH')}
     return devices_dict
+
+
+def extract_udevadm_info(usb_port, ID_NAME=None):
+    """
+    Extracts usb device attributes with the given attribute ID_NAME
+
+    example ID_NAME:
+    ID_SERIAL_SHORT
+    ID_MODEL
+    DEVPATH
+    ID_VENDOR_FROM_DATABASE
+    ID_VENDOR
+    """
+    value = None
+    dname = bytes(usb_port[5:], 'utf-8')
+    out = hdu.exec_process([b'udevadm', b'info', b'-n', dname], True)
+    if ID_NAME is None:
+        value = out.decode(encoding='UTF-8')
+    else:
+        for a in out.split(b'\n'):
+            a = a.decode(encoding='UTF-8')
+            if "{}=".format(ID_NAME) in a:
+                value = a.split('=')[-1]
+    return value

--- a/python/tools/README.md
+++ b/python/tools/README.md
@@ -5,11 +5,12 @@ The list of tools can be found by tab completion of 'REx' at the command line:
 ```bash
 >>$ REx
 
-REx_base_calibrate_imu_collect.py         REx_cliff_sensor_calibrate.py             REx_dynamixel_reboot.py                   REx_hello_dynamixel_jog.py                REx_stepper_gains.py
-REx_base_calibrate_imu_process.py         REx_D435i_check.py                        REx_dynamixel_set_baud.py                 REx_stepper_calibration_flash_to_YAML.py  REx_stepper_jog.py
-REx_base_calibrate_wheel_separation.py    REx_dynamixel_id_change.py                REx_firmware_updater.py                   REx_stepper_calibration_run.py            REx_stepper_mechaduino_menu.py
-REx_calibrate_guarded_contact.py          REx_dynamixel_id_scan.py                  REx_gamepad_configure.py                  REx_stepper_calibration_YAML_to_flash.p   REx_usb_reset.py
-REx_calibrate_range.py                    REx_dynamixel_jog.py                      REx_gripper_calibrate.py                  REx_stepper_ctrl_tuning.py                REx_wacc_calibrate.py
+REx_base_calibrate_imu_collect.py         REx_D435i_check.py                        REx_dynamixel_set_baud.py                 REx_stepper_calibration_run.py            REx_usb_reset.py
+REx_base_calibrate_imu_process.py         REx_discover_hello_devices.py             REx_firmware_updater.py                   REx_stepper_calibration_YAML_to_flash.py  REx_wacc_calibrate.py
+REx_base_calibrate_wheel_separation.py    REx_dynamixel_id_change.py                REx_gamepad_configure.py                  REx_stepper_ctrl_tuning.py                
+REx_calibrate_guarded_contact.py          REx_dynamixel_id_scan.py                  REx_gripper_calibrate.py                  REx_stepper_gains.py                      
+REx_calibrate_range.py                    REx_dynamixel_jog.py                      REx_hello_dynamixel_jog.py                REx_stepper_jog.py                        
+REx_cliff_sensor_calibrate.py             REx_dynamixel_reboot.py                   REx_stepper_calibration_flash_to_YAML.py  REx_stepper_mechaduino_menu.py 
 
 ```
 

--- a/python/tools/REx_discover_hello_devices.py
+++ b/python/tools/REx_discover_hello_devices.py
@@ -1,64 +1,317 @@
 #!/usr/bin/env python
 import os
-import unittest
-from stretch_production_tools.bringup_test_utils import Bringup_Test
-from stretch_production_tools.bringup_test_utils import BRI_TestRunner, BRI_TestSuite
-from stretch_production_tools.production_test_utils import find_tty_devices
 import stretch_body.stepper
-import stretch_body.pimu
 from stretch_body.dynamixel_XL430 import DynamixelXL430, DynamixelCommError
-import stretch_body.wacc
-import stretch_body.base
-import time
 import stretch_body.hello_utils as hu
 from stretch_body.device import Device
 import click
 import pprint
 from stretch_factory import hello_device_utils as hdu
+from stretch_body.robot_params import RobotParams
+import argparse
+import sys
 
+hu.print_stretch_re_use()
 
-def find_tty_devices():
-    devices_dict = {}
-    ttyUSB_dev_list = glob.glob('/dev/ttyUSB*')
-    ttyACM_dev_list = glob.glob('/dev/ttyACM*')
-    for d in ttyACM_dev_list:
-        devices_dict[d] = {"serial": extract_udevadm_info(d, 'ID_SERIAL_SHORT'),
-                           "vendor": extract_udevadm_info(d, 'ID_VENDOR'),
-                           "model": extract_udevadm_info(d, 'ID_MODEL'),
-                           "path": extract_udevadm_info(d, 'DEVPATH')}
-    for d in ttyUSB_dev_list:
-        devices_dict[d] = {"serial": extract_udevadm_info(d, 'ID_SERIAL_SHORT'),
-                           "vendor": extract_udevadm_info(d, 'ID_VENDOR'),
-                           "model": extract_udevadm_info(d, 'ID_MODEL'),
-                           "path": extract_udevadm_info(d, 'DEVPATH')}
-    return devices_dict
-
-
-def extract_udevadm_info(usb_port, ID_NAME=None):
-    """
-    Extracts usb device attributes with the given attribute ID_NAME
-
-    example ID_NAME:
-    ID_SERIAL_SHORT
-    ID_MODEL
-    DEVPATH
-    ID_VENDOR_FROM_DATABASE
-    ID_VENDOR
-    """
-    value = None
-    dname = bytes(usb_port[5:], 'utf-8')
-    out = hdu.exec_process([b'udevadm', b'info', b'-n', dname], True)
-    if ID_NAME is None:
-        value = out.decode(encoding='UTF-8')
-    else:
-        for a in out.split(b'\n'):
-            a = a.decode(encoding='UTF-8')
-            if "{}=".format(ID_NAME) in a:
-                value = a.split('=')[-1]
-    return value
+parser = argparse.ArgumentParser(description="Find and map all the robot specific USB devices (Lift, Arm, Left and Righ wheels, Head, Wrist/End-of-arm) and assign it to a robot.\nThis script is to be run everytime a PCBA hardware or a motor assembly is replaced.")
+args = parser.parse_args()
 
 
 class DiscoverHelloDevices:
     def __int__(self):
-        self.all_tty_devices = find_tty_devices()
+        self.all_tty_devices = hdu.find_tty_devices()
+        if len(list(self.all_tty_devices.keys())) == 0:
+            print(click.style("None ttyACM* or ttyUSB* devices were found in the bus.", fg="red"))
+            sys.exit()
+        self.hello_arduino_devices = {}
+        self.hello_dxl_devices = {}
 
+        self.hello_stepper_devices = {}
+        self.hello_stepper_sns = {"hello-motor-lift": None,
+                                  "hello-motor-arm": None,
+                                  "hello-motor-right-wheel": None,
+                                  "hello-motor-left-wheel": None}
+        self.hello_dxl_sns = {"hello-dynamixel-head": None,
+                              "hello-dynamixel-wrist": None}
+        self.hello_usb_alias = {}
+        self.hello_pimu_sn = {'hello-pimu': None}
+        self.hello_wacc_sn = {'hello-wacc': None}
+        self.robot_tool = RobotParams.get_params()[1]['robot']['tool']
+
+    def get_all_stepper_poses(self):
+        poses = {}
+        for k in list(self.hello_stepper_devices.keys()):
+            motor = stretch_body.stepper.Stepper(usb=k, name='hello-motor-left-wheel')
+            self.assertTrue(motor.startup(), "Unable to start stepper motor at {}".format(k))
+            motor.pull_status()
+            poses[k] = motor.status['pos']
+            motor.stop()
+        return poses
+
+    def get_base_wheels_poses(self, left_wheel, right_wheel):
+        poses = {'left_wheel': None, 'right_wheel': None}
+        left_motor = stretch_body.stepper.Stepper(usb=left_wheel, name='hello-motor-left-wheel')
+        right_motor = stretch_body.stepper.Stepper(usb=right_wheel, name='hello-motor-left-wheel')
+        self.assertTrue(left_motor.startup())
+        self.assertTrue(right_motor.startup())
+        left_motor.pull_status()
+        right_motor.pull_status()
+        poses['left_wheel'] = left_motor.status['pos']
+        poses['right_wheel'] = right_motor.status['pos']
+        left_motor.stop()
+        right_motor.stop()
+        return poses
+
+    def get_moved_motor(self, start_poses, end_poses):
+        pos_diff_thresh = 0.8
+        moved_motors = {}
+        for k in list(start_poses.keys()):
+            pos_diff = start_poses[k] - end_poses[k]
+            if abs(pos_diff) > pos_diff_thresh:
+                moved_motors[k] = True
+                print("Motor in {} was moved by {}".format(k, pos_diff))
+            else:
+                moved_motors[k] = False
+        return moved_motors
+
+    def assertEqual(self, a, b, msg=None):
+        if a == b:
+            return True
+        else:
+            if msg is not None:
+                print(click.style(msg, fg='red'))
+            return False
+
+    def assertIsNotNone(self, a, msg=None):
+        if a is None:
+            if msg is not None:
+                print(click.style(msg, fg='red'))
+            return False
+        else:
+            return True
+
+    def assertTrue(self, a, msg=None):
+        if a == True:
+            return True
+        else:
+            if msg is not None:
+                print(click.style(msg, fg='red'))
+            return False
+
+    def get_arduino_devices(self):
+        """
+        Populate all the devices with Arduino_LLC vendor and grab unique device model serial numbers
+        """
+        for k in self.all_tty_devices.keys():
+            if self.all_tty_devices[k]['vendor'] == 'Arduino_LLC':
+                dev = self.all_tty_devices[k]
+
+                self.hello_arduino_devices[k] = dev
+
+                if dev['model'] == 'Hello_Stepper':
+                    self.hello_stepper_devices[k] = dev
+                elif dev['model'] == 'Hello_Pimu':
+                    self.hello_pimu_sn['hello-pimu'] = dev['serial']
+                elif dev['model'] == 'Hello_Wacc':
+                    self.hello_wacc_sn['hello-wacc'] = dev['serial']
+
+        print("Found {} Arduino devices:".format(len(self.hello_arduino_devices.keys())))
+        pprint.pprint(self.hello_arduino_devices)
+        print("\n")
+        print("Found {} hello_stepper devices.".format(len(self.hello_stepper_devices.keys())))
+        print("Found hello-pimu serial: {}".format(self.hello_pimu_sn['hello-pimu']))
+        print("Found hello-wacc serial: {}".format(self.hello_wacc_sn['hello-wacc']))
+
+        self.assertEqual(len(self.hello_arduino_devices.keys()), 6, "Unable to find the correct no. arduino devices.")
+        self.assertEqual(len(self.hello_stepper_devices.keys()), 4,
+                         "Unable to find the correct no. hello_stepper devices.")
+        self.assertIsNotNone(self.hello_pimu_sn, "Unable to find PIMU Serial")
+        self.assertIsNotNone(self.hello_wacc_sn, "Unable to find WACC Serial")
+
+    def get_dxl_devices(self):
+        """
+        Populate all the devices with FTDI vendor (dynamixel driver)
+        """
+        for k in self.all_tty_devices.keys():
+            if self.all_tty_devices[k]['vendor'] == 'FTDI':
+                self.hello_dxl_devices[k] = self.all_tty_devices[k]
+        print("Found {} dxl devices:".format(len(self.hello_dxl_devices.keys())))
+        pprint.pprint(self.hello_dxl_devices, width=40)
+
+        self.assertEqual(len(self.hello_dxl_devices.keys()), 2, "Unable to find the correct no. FTDI devices.")
+
+    def get_lift_sn(self):
+        """
+        Find the Serial number of the Lift motor serial by detecting a manual movement
+        """
+        input(click.style("WARNING: The Lift would drop, make sure the clamp is underneath lift. Then hit ENTER",
+                          fg="blue", bold=True))
+        start_pose = self.get_all_stepper_poses()
+        input(click.style("Move the Lift joint manually, placing clamp underneath when done. Then hit ENTER", fg="blue",
+                          bold=True))
+        end_pose = self.get_all_stepper_poses()
+        moved_motors = self.get_moved_motor(start_pose, end_pose)
+        cnt = list(moved_motors.values()).count(True)
+        self.assertEqual(cnt, 1, "More than one motor or none moved")
+        lift_sn = None
+        for k in list(moved_motors.keys()):
+            if moved_motors[k]:
+                lift_sn = self.all_tty_devices[k]['serial']
+                self.hello_usb_alias[k] = "/dev/hello-motor-lift"
+        self.assertIsNotNone(lift_sn, "Unable to get Lift Serial")
+        self.hello_stepper_sns['hello-motor-lift'] = lift_sn
+        print(click.style("Found hello-motor-lift serial: {}".format(lift_sn), fg='green'))
+
+    def get_arm_sn(self):
+        """
+        Find the Serial number of the Arm motor serial by detecting a manual movement
+        """
+        start_pose = self.get_all_stepper_poses()
+        input(click.style("Move the Arm joint manually and hit ENTER", fg="blue", bold=True))
+        end_pose = self.get_all_stepper_poses()
+        moved_motors = self.get_moved_motor(start_pose, end_pose)
+        cnt = list(moved_motors.values()).count(True)
+        self.assertEqual(cnt, 1, "More than one motor or none moved")
+        arm_sn = None
+        for k in list(moved_motors.keys()):
+            if moved_motors[k]:
+                arm_sn = self.all_tty_devices[k]['serial']
+                self.hello_usb_alias[k] = "/dev/hello-motor-arm"
+        self.assertIsNotNone(arm_sn, "Unable to get Lift Serial")
+        self.hello_stepper_sns['hello-motor-arm'] = arm_sn
+        print(click.style("Found hello-motor-arm serial: {}".format(arm_sn), fg='green'))
+
+    def get_wheels_sn(self):
+        """
+        Find the Serial number of the wheel motors serial by detecting a manual movement
+        """
+        start_pose = self.get_all_stepper_poses()
+        print('START', start_pose)
+        input(click.style("Move the Base backward manually and hit ENTER", fg="blue", bold=True))
+        end_pose = self.get_all_stepper_poses()
+        print('END', end_pose)
+        moved_motors = self.get_moved_motor(start_pose, end_pose)
+        cnt = list(moved_motors.values()).count(True)
+        self.assertEqual(cnt, 2, "More than two motor or none moved")
+        wheel_motors = [k for k in list(moved_motors.keys()) if moved_motors[k]]
+
+        """Both the unknown sides wheel motor poses are pulled in 'hello-motor-left' wheel configuration. When the 
+        robot is manually back driven forward, the wheel pose difference is -ve and +ve for the left and right wheel 
+        respectively. This logic is used to differentiate left wheel from right wheel"""
+
+        start_pos1 = self.get_base_wheels_poses(wheel_motors[0], wheel_motors[1])
+        input(click.style("Move the base forward manually and hit ENTER", fg="blue", bold=True))
+        end_pose1 = self.get_base_wheels_poses(wheel_motors[0], wheel_motors[1])
+        assumed_left_diff = start_pos1['left_wheel'] - end_pose1['left_wheel']
+        assumed_right_diff = start_pos1['right_wheel'] - end_pose1['right_wheel']
+        left_sn = None
+        right_sn = None
+        if assumed_left_diff < 0 < assumed_right_diff:
+            left_sn = self.all_tty_devices[wheel_motors[0]]['serial']
+            right_sn = self.all_tty_devices[wheel_motors[1]]['serial']
+            self.hello_usb_alias[wheel_motors[0]] = "/dev/hello-motor-left-wheel"
+            self.hello_usb_alias[wheel_motors[1]] = "/dev/hello-motor-right-wheel"
+        else:
+            left_sn = self.all_tty_devices[wheel_motors[1]]['serial']
+            right_sn = self.all_tty_devices[wheel_motors[0]]['serial']
+            self.hello_usb_alias[wheel_motors[1]] = "/dev/hello-motor-left-wheel"
+            self.hello_usb_alias[wheel_motors[0]] = "/dev/hello-motor-right-wheel"
+        self.assertIsNotNone(left_sn, "Unable to find left wheel serial.")
+        self.assertIsNotNone(right_sn, "Unable to find left wheel serial.")
+        self.hello_stepper_sns['hello-motor-left-wheel'] = left_sn
+        self.hello_stepper_sns['hello-motor-right-wheel'] = right_sn
+        print(click.style("Found hello-motor-left-wheel serial: {}".format(left_sn), fg='green'))
+        print(click.style("Found hello-motor-right-wheel serial: {}".format(right_sn), fg='green'))
+
+    def get_servo_ids(self, port, baud_to=115200):
+        found_ids = []
+        print('\nScanning for servo at port: {}'.format(port))
+        print('----------------------------------------------------------')
+        b = baud_to
+        for id in range(20):
+            print("Checking at ID %d and baud %d" % (id, b))
+            m = DynamixelXL430(id, port, baud=b)
+            m.logger.disabled = True
+            try:
+                if m.startup():
+                    print('Found servo at ID %d and Baud %d' % (id, b))
+                    found_ids.append(id)
+            except DynamixelCommError:
+                print("ping failed for ID: " + str(id))
+                continue
+        return found_ids
+
+    def get_dynamixel_sns(self):
+        """
+        Scan the dxl ports for Servo IDs and find the appropriate dynamixel serial
+        """
+        found_ids = {}
+        for k in list(self.hello_dxl_devices.keys()):
+            found_ids[k] = self.get_servo_ids(k)
+            print("FOUND Servo IDs: {} at port: {}".format(found_ids[k], k))
+
+        head_sn = None
+        wrist_sn = None
+        for k in list(found_ids.keys()):
+            if found_ids[k] == [11, 12]:
+                head_sn = self.all_tty_devices[k]['serial']
+                self.hello_usb_alias[k] = "/dev/hello-dynamixel-head"
+            if self.robot_tool == "tool_stretch_dex_wrist":
+                if found_ids[k] == [13, 14, 15, 16]:
+                    wrist_sn = self.all_tty_devices[k]['serial']
+                    self.hello_usb_alias[k] = "/dev/hello-dynamixel-wrist"
+            else:
+                if found_ids[k] == [13, 14]:
+                    wrist_sn = self.all_tty_devices[k]['serial']
+                    self.hello_usb_alias[k] = "/dev/hello-dynamixel-wrist"
+        self.assertIsNotNone(head_sn)
+        self.assertIsNotNone(wrist_sn)
+        self.hello_dxl_sns["hello-dynamixel-head"] = head_sn
+        self.hello_dxl_sns["hello-dynamixel-wrist"] = wrist_sn
+        print("\n")
+        print("Found hello-dynamixel-head serial: {}".format(head_sn))
+        print("Found hello-dynamixel-wrist serial: {}".format(wrist_sn))
+
+    def push_sns_to_udev_rules(self):
+        """
+        Update the Udev files with the found Serial numbers for hello* devices
+        """
+
+        os.system("chmod -R 777 ~/stretch_user")
+        print("Assigning Stepper motor SN to robot....")
+        for k in list(self.hello_stepper_sns.keys()):
+            hdu.add_arduino_udev_line(device_name=k, serial_no=self.hello_stepper_sns[k],
+                                      fleet_dir=hu.get_fleet_directory())
+            dev = Device(k)
+            dev.write_configuration_param_to_YAML("{}.serial_no".format(k), self.hello_stepper_sns[k],
+                                                  hu.get_fleet_directory())
+
+        print("Assigning Pimu and Wacc SN to robot....")
+        hdu.add_arduino_udev_line(device_name="hello-pimu", serial_no=self.hello_pimu_sn['hello-pimu'],
+                                  fleet_dir=hu.get_fleet_directory())
+        hdu.add_arduino_udev_line(device_name="hello-wacc", serial_no=self.hello_wacc_sn['hello-wacc'],
+                                  fleet_dir=hu.get_fleet_directory())
+
+        print("Assigning FTDI devices SN to robot....")
+        for k in list(self.hello_dxl_sns.keys()):
+            hdu.add_ftdi_udev_line(device_name=k, serial_no=self.hello_dxl_sns[k], fleet_dir=hu.get_fleet_directory())
+
+        print("Pushing Udev files to /etc/udev/rules.d/....")
+        os.system("sudo cp {}udev/95-hello-arduino.rules /etc/udev/rules.d/".format(hu.get_fleet_directory()))
+        os.system("sudo cp {}udev/99-hello-dynamixel.rules /etc/udev/rules.d/".format(hu.get_fleet_directory()))
+        os.system("sudo udevadm control --reload; sudo udevadm trigger")
+
+        print(click.style('### UDEV RULES UPDATED ###', fg='green', bold=True))
+
+    def run(self):
+        self.get_arduino_devices()
+        self.get_dxl_devices()
+        self.get_lift_sn()
+        self.get_arm_sn()
+        self.get_wheels_sn()
+        self.get_dynamixel_sns()
+        self.push_sns_to_udev_rules()
+
+
+discover_hello_devices = DiscoverHelloDevices()
+discover_hello_devices.run()

--- a/python/tools/REx_discover_hello_devices.py
+++ b/python/tools/REx_discover_hello_devices.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+import os
+import unittest
+from stretch_production_tools.bringup_test_utils import Bringup_Test
+from stretch_production_tools.bringup_test_utils import BRI_TestRunner, BRI_TestSuite
+from stretch_production_tools.production_test_utils import find_tty_devices
+import stretch_body.stepper
+import stretch_body.pimu
+from stretch_body.dynamixel_XL430 import DynamixelXL430, DynamixelCommError
+import stretch_body.wacc
+import stretch_body.base
+import time
+import stretch_body.hello_utils as hu
+from stretch_body.device import Device
+import click
+import pprint
+from stretch_factory import hello_device_utils as hdu
+
+
+def find_tty_devices():
+    devices_dict = {}
+    ttyUSB_dev_list = glob.glob('/dev/ttyUSB*')
+    ttyACM_dev_list = glob.glob('/dev/ttyACM*')
+    for d in ttyACM_dev_list:
+        devices_dict[d] = {"serial": extract_udevadm_info(d, 'ID_SERIAL_SHORT'),
+                           "vendor": extract_udevadm_info(d, 'ID_VENDOR'),
+                           "model": extract_udevadm_info(d, 'ID_MODEL'),
+                           "path": extract_udevadm_info(d, 'DEVPATH')}
+    for d in ttyUSB_dev_list:
+        devices_dict[d] = {"serial": extract_udevadm_info(d, 'ID_SERIAL_SHORT'),
+                           "vendor": extract_udevadm_info(d, 'ID_VENDOR'),
+                           "model": extract_udevadm_info(d, 'ID_MODEL'),
+                           "path": extract_udevadm_info(d, 'DEVPATH')}
+    return devices_dict
+
+
+def extract_udevadm_info(usb_port, ID_NAME=None):
+    """
+    Extracts usb device attributes with the given attribute ID_NAME
+
+    example ID_NAME:
+    ID_SERIAL_SHORT
+    ID_MODEL
+    DEVPATH
+    ID_VENDOR_FROM_DATABASE
+    ID_VENDOR
+    """
+    value = None
+    dname = bytes(usb_port[5:], 'utf-8')
+    out = hdu.exec_process([b'udevadm', b'info', b'-n', dname], True)
+    if ID_NAME is None:
+        value = out.decode(encoding='UTF-8')
+    else:
+        for a in out.split(b'\n'):
+            a = a.decode(encoding='UTF-8')
+            if "{}=".format(ID_NAME) in a:
+                value = a.split('=')[-1]
+    return value
+
+
+class DiscoverHelloDevices:
+    def __int__(self):
+        self.all_tty_devices = find_tty_devices()
+

--- a/python/tools/REx_discover_hello_devices.py
+++ b/python/tools/REx_discover_hello_devices.py
@@ -14,9 +14,10 @@ import sys
 hu.print_stretch_re_use()
 
 parser = argparse.ArgumentParser(
-    description="Find and map all the robot specific USB devices (Lift, Arm, Left and Right wheels, Head, "
-                "Wrist/End-of-arm) and assign it to the robot.\nThis tool can be utilized everytime "
-                "a PCBA, motor assembly is replaced or /dev/hello-* devices goes missing from the  USB bus.")
+    description="Find and map all the robot-specific USB devices (i.e. Lift, Arm, Left wheel, Right wheel, Head, "
+                "Wrist/End-of-arm) and assign them to the robot by updating the UDEV rules and stretch configuration "
+                "files.This tool can be utilized everytime a PCBA, motor assembly is replaced or if any /dev/hello-* "
+                "devices go missing from the  USB bus.")
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument("--discover", help="Discover the devices by set of user instructions and re-assign them to the robot",


### PR DESCRIPTION
This PR introduces the new tool **`REx_discover_hello_devices.py`**. 
- This tool will enable users to find and map all the robot-specific USB devices (i.e. Lift, Arm, Left wheel, Right wheel, Head, Wrist/End-of-arm) and assign them to the robot by updating UDEV rules and stretch configuration files.
- This tool prompts the users to move the robot manually in a specific manner, and based on the joint movements, the hello-* device assignments are done. This tool supports stretch_gripper and stretch_dex_wrist  tool configurations.
- This tool can be recommended to users every time a PCBA, or motor assembly is replaced or when any `/dev/hello-*` devices go missing from the USB bus for debugging.
#### Usage
```
For use with S T R E T C H (R) RESEARCH EDITION from Hello Robot Inc.
---------------------------------------------------------------------

usage: REx_discover_hello_devices.py [-h] [--discover | --list_tty]

Find and map all the robot-specific USB devices (i.e. Lift, Arm, Left wheel, Right wheel, Head, Wrist/End-of-arm) and assign them to
the robot by updating the UDEV rules and stretch configuration files.This tool can be utilized everytime a PCBA, motor assembly is
replaced or if any /dev/hello-* devices go missing from the USB bus.

optional arguments:
  -h, --help  show this help message and exit
  --discover  Discover the devices by set of user instructions and re-assign them to the robot
  --list_tty  Display the currently available devices info(model,path,serial,vendor) in the paths /dev/ttyACM* and /dev/ttyUSB*
```
cmd : `REx_discover_hello_devices.py --discover` [Example output](https://gist.github.com/hello-fazil/8d19e36ce1f0090a3766ea58a90bb605)