### PR TITLE
Hello discover devices type specific

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ stretch_scripts=[f for f in ex_scripts if isfile(f)]
 
 setuptools.setup(
     name="hello_robot_stretch_factory",
-    version="0.3.12",
+    version="0.3.13",
     author="Hello Robot Inc.",
     author_email="support@hello-robot.com",
     description="Stretch Factory Tools",

--- a/python/tools/REx_discover_hello_devices.py
+++ b/python/tools/REx_discover_hello_devices.py
@@ -26,7 +26,7 @@ group.add_argument("--discover",
 group.add_argument("--list_tty",
                    help="Display the currently available devices's info(model,path,serial,vendor) present in /dev/ttyACM* and /dev/ttyUSB*",
                    action="store_true")
-parser.add_argument("--stepper", help="Discover Stepper motor devices only.", action="store_true")
+parser.add_argument("--arduino", help="Discover arduino/stepper devices only.", action="store_true")
 parser.add_argument("--dynamixel", help="Discover Dynamixel servo motor devices only.", action="store_true")
 args = parser.parse_args()
 
@@ -288,8 +288,8 @@ class DiscoverHelloDevices:
         """
         Update the Udev files with the found Serial numbers for hello* devices
         """
-        self.push_stepper_sns_to_udev_rules()
-        self.push_stepper_sns_to_udev_rules()
+        self.push_arduino_sns_to_udev_rules()
+        self.push_dynamixel_sns_to_udev_rules()
         # print(click.style('UDEV rules and stretch configuration files updated', fg='green', bold=True))
 
     def push_dynamixel_sns_to_udev_rules(self):
@@ -306,9 +306,10 @@ class DiscoverHelloDevices:
                 os.system("sudo udevadm control --reload; sudo udevadm trigger")
             except Exception as err:
                 print(click.style('ERROR [{}]: {}'.format(k, str(err)), fg='red'))
-        print(click.style('UDEV rules and stretch configuration files specific to Dynamixels updated', fg='green', bold=True))
+        print(click.style('UDEV rules and stretch configuration files specific to Dynamixels updated', fg='green',
+                          bold=True))
 
-    def push_stepper_sns_to_udev_rules(self):
+    def push_arduino_sns_to_udev_rules(self):
         os.system("chmod -R 777 ~/stretch_user")
         print("Assigning Stepper motor SN to robot....")
 
@@ -333,7 +334,8 @@ class DiscoverHelloDevices:
                                       fleet_dir=hu.get_fleet_directory())
         except Exception as err:
             print(click.style('ERROR [{}]: {}'.format("hello-wacc", str(err)), fg='red'))
-        print(click.style('UDEV rules and stretch configuration files specific to Stepper motors updated', fg='green', bold=True))
+        print(click.style('UDEV rules and stretch configuration files specific to arduino devices updated', fg='green',
+                          bold=True))
 
     def run(self):
         if len(list(self.all_tty_devices.keys())) == 0:
@@ -355,7 +357,7 @@ class DiscoverHelloDevices:
         self.get_dynamixel_sns()
         self.push_dynamixel_sns_to_udev_rules()
 
-    def run_stepper(self):
+    def run_arduino(self):
         if len(list(self.all_tty_devices.keys())) == 0:
             print(click.style("No ttyACM* or ttyUSB* devices were found in the USB bus.", fg="red"))
             sys.exit()
@@ -363,15 +365,15 @@ class DiscoverHelloDevices:
         self.get_lift_sn()
         self.get_arm_sn()
         self.get_wheels_sn()
-        self.push_stepper_sns_to_udev_rules()
+        self.push_arduino_sns_to_udev_rules()
 
 
 if args.list_tty:
     discover_hello_devices = DiscoverHelloDevices()
     pprint.pprint(discover_hello_devices.all_tty_devices)
-elif args.discover and args.stepper:
+elif args.discover and args.arduino:
     discover_hello_devices = DiscoverHelloDevices()
-    discover_hello_devices.run_stepper()
+    discover_hello_devices.run_arduino()
 elif args.discover and args.dynamixel:
     discover_hello_devices = DiscoverHelloDevices()
     discover_hello_devices.run_dynamixel()


### PR DESCRIPTION
This PR adds a feature to the [REx_discover_hello_devices.py](https://github.com/hello-robot/stretch_factory/blob/master/python/tools/REx_discover_hello_devices.py) that allows the option of discovering and assigning Arduino and dynamixel devices separately to improve debugging practices.

```
For use with S T R E T C H (R) RESEARCH EDITION from Hello Robot Inc.
---------------------------------------------------------------------

usage: REx_discover_hello_devices.py [-h] [--discover | --list_tty] [--arduino] [--dynamixel]

Find and map all the robot-specific USB devices (i.e. stepper motors: {Lift, Arm, Left wheel, Right wheel} and dynamixel servos:
{Head,Wrist/End-of-arm}). Then assign the found devices to the robot by updating the UDEV rules and stretch configuration files.This
tool can be utilized everytime a PCBA, motor assembly is replaced or if any /dev/hello-* devices go missing from the USB bus.

optional arguments:
  -h, --help   show this help message and exit
  --discover   Discover the devices by set of user instructions and re-assign them to the robot
  --list_tty   Display the currently available devices's info(model,path,serial,vendor) present in /dev/ttyACM* and /dev/ttyUSB*
  --arduino    Discover arduino/stepper devices only.
  --dynamixel  Discover Dynamixel servo motor devices only.
```
