### PR TITLE
Bugfix/firmware updater 1021

### DIFF
--- a/python/stretch_factory/firmware_available.py
+++ b/python/stretch_factory/firmware_available.py
@@ -1,0 +1,110 @@
+import click
+import os
+import git
+import sys
+from stretch_factory.firmware_version import FirmwareVersion
+
+class FirmwareAvailable():
+    """
+    Determine what firmware is available on GIT
+    """
+    def __init__(self, use_device):
+        self.use_device = use_device #True/False dict for each device name
+        self.repo = None
+        self.repo_path = None
+        self.versions = {}
+        for d in self.use_device:
+            if self.use_device[d]:
+                self.versions[d] = []  # List of available versions for that device
+        self.__clone_firmware_repo()
+        self.__get_available_firmware_versions()
+
+    def __clone_firmware_repo(self):
+        print('Collecting information...')
+        self.repo_path = '/tmp/stretch_firmware_update'
+        if not os.path.isdir(self.repo_path):
+            # print('Cloning latest version of Stretch Firmware to %s'% self.repo_path)
+            try:
+                git.Repo.clone_from('https://github.com/hello-robot/stretch_firmware', self.repo_path)
+            except git.GitCommandError as e:
+                if "could not resolve host" in e.stderr.lower():
+                    print("ERROR: Unable to connect to Github. Check internet connection?", file=sys.stderr)
+                else:
+                    print("ERROR: Unable to clone stretch_firmware from Github into /tmp/stretch_firmware_update.",
+                          file=sys.stderr)
+                sys.exit(1)
+
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        self.repo = git.Repo(self.repo_path)
+        os.chdir(self.repo_path)
+
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        os.system('git checkout master >/dev/null 2>&1')
+
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        os.system('git fetch --tags >/dev/null 2>&1 ')
+
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        os.system('git pull >/dev/null 2>&1 ')
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        print('\n')
+
+    def pretty_print(self):
+        click.secho(' Currently Tagged Versions of Stretch Firmware on Master Branch '.center(110, '#'), fg="cyan",
+                    bold=True)
+        for device_name in self.versions:#.keys():
+            click.secho('---- %s ----' % device_name.upper(), fg="white", bold=True)
+            for v in self.versions[device_name]:
+                print(v)
+
+    # python -m pip install gitpython
+    # https://www.devdungeon.com/content/working-git-repositories-python
+    def __get_available_firmware_versions(self):
+        if self.repo is None:
+            return
+        for t in self.repo.tags:
+            v = FirmwareVersion(t.name)
+            if v.valid:
+                for device_name in self.versions:
+                    if (v.device == 'Stepper' and device_name in ['hello-motor-lift', 'hello-motor-arm',
+                                                                  'hello-motor-left-wheel',
+                                                                  'hello-motor-right-wheel']) or \
+                            (v.device == 'Wacc' and device_name == 'hello-wacc') or \
+                            (v.device == 'Pimu' and device_name == 'hello-pimu'):
+                        self.versions[device_name].append(v)
+
+    def get_most_recent_version(self, device_name, supported_protocols):
+        """
+        For the device and supported protocol versions (eg, '['p0','p1']'), return the most recent version (type FirmwareVersion)
+        """
+        if len(self.versions[device_name]) == 0:
+            return None
+        recent = None
+        s = [int(x[1:]) for x in supported_protocols]
+        supported_versions = []
+        for v in self.versions[device_name]:
+            if v.protocol in s:
+                supported_versions.append(v)
+        for sv in supported_versions:
+            if recent is None or sv > recent:
+                recent = sv
+        return recent
+
+    def get_remote_branches(self):
+        branches = []
+        print('Collecting information...')
+        for ref in self.repo.git.branch('-r').split('\n'):
+            sys.stdout.write('.')
+            sys.stdout.flush()
+            branches.append(ref)
+        print('\n')
+        branches = [b.strip(' ') for b in branches if b.find('HEAD') == -1]
+        branches.remove('origin/master')  # Move master to position 0
+        branches = ['origin/master'] + branches
+        return branches
+

--- a/python/stretch_factory/firmware_installed.py
+++ b/python/stretch_factory/firmware_installed.py
@@ -22,6 +22,16 @@ class FirmwareInstalled():
         """
         use_device has form of:
         {'hello-motor-lift': True, 'hello-motor-arm': True, 'hello-motor-right-wheel': True, 'hello-motor-left-wheel': True, 'hello-pimu': True, 'hello-wacc': True}
+
+        config_info is a dict like:
+
+        {'hello-motor-lift': {'board_info': {'board_variant': 'Stepper.0',
+           'firmware_version': 'Stepper.v0.3.0p2',
+           'protocol_version': 'p2',
+           'hardware_id': 0},
+          'supported_protocols': ['p0', 'p1', 'p2'],
+          'installed_protocol_valid': True,
+          'version': 'Stepper.v0.3.0p2'},...}
         """
         self.use_device = use_device
         self.config_info = {'hello-motor-lift': None, 'hello-motor-arm': None, 'hello-motor-left-wheel': None,
@@ -40,14 +50,13 @@ class FirmwareInstalled():
                     self.config_info[device] = {}
                     self.config_info[device]['board_info'] = dd.board_info.copy()
                     try:
-                        self.config_info[device]['supported_protocols'] = dd.supported_protocols.keys()
+                        self.config_info[device]['supported_protocols'] = list(dd.supported_protocols.keys())
                     except AttributeError:
                         # Older versions of stretch body used a different represenation
                         self.config_info[device]['supported_protocols'] = [dd.valid_firmware_protocol]
                     self.config_info[device]['installed_protocol_valid'] = (
                                 dd.board_info['protocol_version'] in self.config_info[device]['supported_protocols'])
-                    self.config_info[device]['version'] = FirmwareVersion(
-                        self.config_info[device]['board_info']['firmware_version'])
+                    self.config_info[device]['version'] = FirmwareVersion(self.config_info[device]['board_info']['firmware_version'])
                     dd.stop()
                 else:
                     self.config_info[device] = None

--- a/python/stretch_factory/firmware_installed.py
+++ b/python/stretch_factory/firmware_installed.py
@@ -45,21 +45,23 @@ class FirmwareInstalled():
                     dd = stretch_body.pimu.Pimu()
                 else:
                     dd = stretch_body.stepper.Stepper('/dev/' + device)
-                dd.startup()
-                if dd.board_info['firmware_version'] is not None:  # Was able to pull board info from device
-                    self.config_info[device] = {}
-                    self.config_info[device]['board_info'] = dd.board_info.copy()
-                    try:
-                        self.config_info[device]['supported_protocols'] = list(dd.supported_protocols.keys())
-                    except AttributeError:
-                        # Older versions of stretch body used a different represenation
-                        self.config_info[device]['supported_protocols'] = [dd.valid_firmware_protocol]
-                    self.config_info[device]['installed_protocol_valid'] = (
-                                dd.board_info['protocol_version'] in self.config_info[device]['supported_protocols'])
-                    self.config_info[device]['version'] = FirmwareVersion(self.config_info[device]['board_info']['firmware_version'])
-                    dd.stop()
+                if not dd.startup():
+                    click.secho('Unable to communicate with device %s'%device,fg="red", bold=True)
                 else:
-                    self.config_info[device] = None
+                    if dd.board_info['firmware_version'] is not None:  # Was able to pull board info from device
+                        self.config_info[device] = {}
+                        self.config_info[device]['board_info'] = dd.board_info.copy()
+                        try:
+                            self.config_info[device]['supported_protocols'] = list(dd.supported_protocols.keys())
+                        except AttributeError:
+                            # Older versions of stretch body used a different represenation
+                            self.config_info[device]['supported_protocols'] = [dd.valid_firmware_protocol]
+                        self.config_info[device]['installed_protocol_valid'] = (
+                                    dd.board_info['protocol_version'] in self.config_info[device]['supported_protocols'])
+                        self.config_info[device]['version'] = FirmwareVersion(self.config_info[device]['board_info']['firmware_version'])
+                        dd.stop()
+                    else:
+                        self.config_info[device] = None
 
     def get_supported_protocols(self, device_name):
         if self.is_device_valid(device_name):

--- a/python/stretch_factory/firmware_installed.py
+++ b/python/stretch_factory/firmware_installed.py
@@ -1,0 +1,95 @@
+import click
+import stretch_body.stepper
+import stretch_body.pimu
+import stretch_body.wacc
+import stretch_body.device
+import stretch_body.device
+import stretch_body.hello_utils
+from stretch_factory.firmware_version import FirmwareVersion
+
+class FirmwareInstalled():
+    """
+    Pull the current installed firmware off the robot uCs
+    Build config_info of form:
+    {'hello-motor-arm': {'board_info': {'board_version': u'Stepper.Irma.V1',
+       'firmware_version': u'Stepper.v0.0.1p1',
+       'protocol_version': u'p1'},
+      'installed_protocol_valid': True,
+      'supported_protocols': ['p0', 'p1']}}
+    """
+
+    def __init__(self, use_device):
+        """
+        use_device has form of:
+        {'hello-motor-lift': True, 'hello-motor-arm': True, 'hello-motor-right-wheel': True, 'hello-motor-left-wheel': True, 'hello-pimu': True, 'hello-wacc': True}
+        """
+        self.use_device = use_device
+        self.config_info = {'hello-motor-lift': None, 'hello-motor-arm': None, 'hello-motor-left-wheel': None,
+                            'hello-motor-right-wheel': None, 'hello-pimu': None, 'hello-wacc': None}
+        print('Collecting information...')
+        for device in self.use_device.keys():
+            if self.use_device[device]:
+                if device == 'hello-wacc':
+                    dd = stretch_body.wacc.Wacc()
+                elif device == 'hello-pimu':
+                    dd = stretch_body.pimu.Pimu()
+                else:
+                    dd = stretch_body.stepper.Stepper('/dev/' + device)
+                dd.startup()
+                if dd.board_info['firmware_version'] is not None:  # Was able to pull board info from device
+                    self.config_info[device] = {}
+                    self.config_info[device]['board_info'] = dd.board_info.copy()
+                    try:
+                        self.config_info[device]['supported_protocols'] = dd.supported_protocols.keys()
+                    except AttributeError:
+                        # Older versions of stretch body used a different represenation
+                        self.config_info[device]['supported_protocols'] = [dd.valid_firmware_protocol]
+                    self.config_info[device]['installed_protocol_valid'] = (
+                                dd.board_info['protocol_version'] in self.config_info[device]['supported_protocols'])
+                    self.config_info[device]['version'] = FirmwareVersion(
+                        self.config_info[device]['board_info']['firmware_version'])
+                    dd.stop()
+                else:
+                    self.config_info[device] = None
+
+    def get_supported_protocols(self, device_name):
+        if self.is_device_valid(device_name):
+            return self.config_info[device_name]['supported_protocols']
+        return None
+
+    def get_version(self, device_name):
+        if self.is_device_valid(device_name):
+            return self.config_info[device_name]['version']
+        return None
+
+    def is_device_valid(self, device_name):
+        return self.config_info[device_name] is not None
+
+    def is_protocol_supported(self, device_name, p):
+        """
+        Provide 'p0', etc
+        """
+        return self.is_device_valid(device_name) and p in self.config_info[device_name]['supported_protocols']
+
+    def max_protocol_supported(self, device_name):
+        x = [int(x[1:]) for x in self.config_info[device_name]['supported_protocols']]
+        return 'p' + str(max(x))
+
+    def pretty_print(self):
+        click.secho(' Currently Installed Firmware '.center(110, '#'), fg="cyan", bold=True)
+        for device in self.config_info:
+            if self.use_device[device]:
+                click.secho('------------ %s ------------' % device.upper(), fg="white", bold=True)
+                if self.config_info[device]:
+                    click.echo('Installed Firmware: %s' % self.config_info[device]['board_info']['firmware_version'])
+                    x = " , ".join(["{}"] * len(self.config_info[device]['supported_protocols'])).format(
+                        *self.config_info[device]['supported_protocols'])
+                    click.echo('Installed Stretch Body supports protocols: ' + x)
+                    if self.config_info[device]['installed_protocol_valid']:
+                        click.secho('Installed protocol %s : VALID' % self.config_info[device]['board_info'][
+                            'protocol_version'])
+                    else:
+                        click.secho('Installed protocol %s : INVALID' % self.config_info[device]['board_info'][
+                            'protocol_version'], fg="yellow")
+                else:
+                    click.secho('Device not found')

--- a/python/stretch_factory/firmware_recommended.py
+++ b/python/stretch_factory/firmware_recommended.py
@@ -1,0 +1,74 @@
+
+import click
+from stretch_factory.firmware_installed import FirmwareInstalled
+from stretch_factory.firmware_available import FirmwareAvailable
+
+
+class FirmwareRecommended():
+    """
+    Recommend a firmware version to upgrade to based on available / installed
+    """
+    def __init__(self, use_device, installed=None, available=None):
+        print('Collecting information...')
+        self.use_device = use_device
+        self.fw_installed = FirmwareInstalled(use_device) if installed is None else installed
+        self.fw_available = FirmwareAvailable(use_device) if available is None else available
+        self.recommended = {}
+        self.__get_recommend_updates()
+
+    def __get_recommend_updates(self):
+        for device_name in self.use_device.keys():
+            if self.use_device[device_name]:
+                if self.fw_installed.is_device_valid(device_name):  # Len 0 if device not found
+                    self.recommended[device_name] = self.fw_available.get_most_recent_version(device_name,
+                                                                                              self.fw_installed.get_supported_protocols(
+                                                                                                  device_name))
+                else:
+                    self.recommended[device_name] = None
+
+    def pretty_print(self):
+        click.secho(' Recommended Firmware Updates '.center(110, '#'), fg="cyan", bold=True)
+        print('\n')
+        click.secho('%s | %s | %s | %s ' % (
+        'DEVICE'.ljust(25), 'INSTALLED'.ljust(25), 'RECOMMENDED'.ljust(25), 'ACTION'.ljust(25)), fg="cyan", bold=True)
+        click.secho('-' * 110, fg="cyan", bold=True)
+
+        for device_name in self.recommended: #.keys():
+            dev_out = device_name.upper().ljust(25)
+            installed_out = ''.ljust(25)
+            rec_out = ''.ljust(25)
+            action_out = ''.ljust(25)
+            if not self.fw_installed.is_device_valid(device_name):
+                installed_out = 'No device available'.ljust(25)
+            else:
+                version = self.fw_installed.get_version(device_name)
+                installed_out = str(version).ljust(25)
+                if self.recommended[device_name] == None:
+                    rec_out = 'None (might be on dev branch)'.ljust(25)
+                else:
+                    rec_out = str(self.recommended[device_name]).ljust(25)
+                    if self.recommended[device_name] > version:
+                        action_out = 'Upgrade recommended'.ljust(25)
+                    elif self.recommended[device_name] < version:
+                        action_out = 'Downgrade recommended'.ljust(25)
+                    else:
+                        action_out = 'At most recent version'.ljust(25)
+            print('%s | %s | %s | %s ' % (dev_out, installed_out, rec_out, action_out))
+
+    def print_recommended_args(self):
+        dev_arg_map = {'hello-pimu': ' --pimu', 'hello-wacc': ' --wacc', 'hello-motor-right-wheel': ' --right_wheel',
+                       'hello-motor-left-wheel': ' --left_wheel', 'hello-motor-lift': ' --lift',
+                       'hello-motor-arm': ' --arm'}
+        rec_args = ''
+        for device_name in self.recommended: #.keys():
+            if self.fw_installed.is_device_valid(device_name):
+                version = self.fw_installed.get_version(device_name)
+                if self.recommended[device_name] != None:
+                    if self.recommended[device_name] > version:
+                        rec_args = rec_args + dev_arg_map[device_name]
+        if len(rec_args):
+            click.secho('\nRun recommended command: \nREx_firmware_updater.py --install %s' % rec_args, fg="green",
+                        bold=True)
+        else:
+            click.secho('\nFirmware upgrade not necessary', fg="green", bold=True)
+

--- a/python/stretch_factory/firmware_updater.py
+++ b/python/stretch_factory/firmware_updater.py
@@ -14,35 +14,39 @@ import sys
 import stretch_body.device
 from stretch_factory.device_mgmt import StretchDeviceMgmt
 import stretch_body.hello_utils
-import stretch_factory.hello_device_utils as hdu
+
 
 # #####################################################################################################
 class FirmwareVersion():
     """
     Manage comparision of firmware versions
     """
-    def __init__(self,version_str):
-        self.device='NONE'
-        self.major=0
-        self.minor=0
-        self.bugfix=0
-        self.protocol=0
-        self.valid=False
+
+    def __init__(self, version_str):
+        self.device = 'NONE'
+        self.major = 0
+        self.minor = 0
+        self.bugfix = 0
+        self.protocol = 0
+        self.valid = False
         self.from_string(version_str)
+
     def __str__(self):
         return self.to_string()
+
     def to_string(self):
         """
         Version is represented as Stepper.v0.0.1p0 for example
         """
-        return self.device+'.v'+str(self.major)+'.'+str(self.minor)+'.'+str(self.bugfix)+'p'+str(self.protocol)
+        return self.device + '.v' + str(self.major) + '.' + str(self.minor) + '.' + str(self.bugfix) + 'p' + str(
+            self.protocol)
 
     def __gt__(self, other):
         if not self.valid or not other.valid:
             return False
-        if self.protocol>other.protocol:
+        if self.protocol > other.protocol:
             return True
-        if self.protocol<other.protocol:
+        if self.protocol < other.protocol:
             return False
         if self.major > other.major:
             return True
@@ -55,9 +59,9 @@ class FirmwareVersion():
     def __lt__(self, other):
         if not self.valid or not other.valid:
             return False
-        if self.protocol<other.protocol:
+        if self.protocol < other.protocol:
             return True
-        if self.protocol>other.protocol:
+        if self.protocol > other.protocol:
             return False
         if self.major < other.major:
             return True
@@ -67,38 +71,40 @@ class FirmwareVersion():
             return True
         return False
 
-    def __ne__(self,other):
+    def __ne__(self, other):
         return not self.__eq__(other)
 
-    def __eq__(self,other):
+    def __eq__(self, other):
         if not other or not self.valid or not other.valid:
             return False
-        return self.major == other.major and self.minor == other.minor and self.bugfix == other.bugfix and self.protocol==other.protocol
+        return self.major == other.major and self.minor == other.minor and self.bugfix == other.bugfix and self.protocol == other.protocol
 
-    def same_device(self,d):
-        return d==self.device
+    def same_device(self, d):
+        return d == self.device
 
-    def from_string(self,x):
-        #X is of form 'Stepper.v0.0.1p0'
+    def from_string(self, x):
+        # X is of form 'Stepper.v0.0.1p0'
         try:
-            xl=x.split('.')
+            xl = x.split('.')
             if len(xl) != 4:
                 raise Exception('Invalid version len')
-            device=xl[0]
-            if not (device=='Stepper' or device=='Wacc' or device=='Pimu'):
+            device = xl[0]
+            if not (device == 'Stepper' or device == 'Wacc' or device == 'Pimu'):
                 raise Exception('Invalid device name ')
-            major=int(xl[1][1:])
-            minor=int(xl[2])
-            bugfix=int(xl[3][0:xl[3].find('p')])
-            protocol=int(xl[3][(xl[3].find('p')+1):])
-            self.device=device
-            self.major=major
-            self.minor=minor
-            self.bugfix=bugfix
-            self.protocol=protocol
-            self.valid=True
-        except(ValueError,Exception):
-            print('Invalid version format in tag: %s'%x)
+            major = int(xl[1][1:])
+            minor = int(xl[2])
+            bugfix = int(xl[3][0:xl[3].find('p')])
+            protocol = int(xl[3][(xl[3].find('p') + 1):])
+            self.device = device
+            self.major = major
+            self.minor = minor
+            self.bugfix = bugfix
+            self.protocol = protocol
+            self.valid = True
+        except(ValueError, Exception):
+            print('Invalid version format in tag: %s' % x)
+
+
 # #####################################################################################################
 class InstalledFirmware():
     """
@@ -110,82 +116,93 @@ class InstalledFirmware():
       'installed_protocol_valid': True,
       'supported_protocols': ['p0', 'p1']}}
     """
-    def __init__(self,use_device):
+
+    def __init__(self, use_device):
         """
         use_device has form of:
         {'hello-motor-lift': True, 'hello-motor-arm': True, 'hello-motor-right-wheel': True, 'hello-motor-left-wheel': True, 'hello-pimu': True, 'hello-wacc': True}
         """
-        self.use_device=use_device
-        self.config_info={'hello-motor-lift': None,'hello-motor-arm':None,'hello-motor-left-wheel':None,'hello-motor-right-wheel':None,'hello-pimu':None,'hello-wacc':None}
+        self.use_device = use_device
+        self.config_info = {'hello-motor-lift': None, 'hello-motor-arm': None, 'hello-motor-left-wheel': None,
+                            'hello-motor-right-wheel': None, 'hello-pimu': None, 'hello-wacc': None}
         for device in self.config_info.keys():
             if self.use_device[device]:
-                if device=='hello-wacc':
-                    dd=stretch_body.wacc.Wacc()
+                if device == 'hello-wacc':
+                    dd = stretch_body.wacc.Wacc()
                 elif device == 'hello-pimu':
                     dd = stretch_body.pimu.Pimu()
                 else:
-                    dd=stretch_body.stepper.Stepper('/dev/'+device)
+                    dd = stretch_body.stepper.Stepper('/dev/' + device)
                 dd.startup()
-                if dd.board_info['firmware_version'] is not None: #Was able to pull board info from device
-                    self.config_info[device]={}
+                if dd.board_info['firmware_version'] is not None:  # Was able to pull board info from device
+                    self.config_info[device] = {}
                     self.config_info[device]['board_info'] = dd.board_info.copy()
                     try:
-                        self.config_info[device]['supported_protocols']=dd.supported_protocols.keys()
+                        self.config_info[device]['supported_protocols'] = dd.supported_protocols.keys()
                     except AttributeError:
-                        #Older versions of stretch body used a different represenation
-                        self.config_info[device]['supported_protocols']=[dd.valid_firmware_protocol]
-                    self.config_info[device]['installed_protocol_valid']=(dd.board_info['protocol_version']in self.config_info[device]['supported_protocols'])
-                    self.config_info[device]['version']=FirmwareVersion(self.config_info[device]['board_info']['firmware_version'])
+                        # Older versions of stretch body used a different represenation
+                        self.config_info[device]['supported_protocols'] = [dd.valid_firmware_protocol]
+                    self.config_info[device]['installed_protocol_valid'] = (
+                                dd.board_info['protocol_version'] in self.config_info[device]['supported_protocols'])
+                    self.config_info[device]['version'] = FirmwareVersion(
+                        self.config_info[device]['board_info']['firmware_version'])
                     dd.stop()
                 else:
-                    self.config_info[device]=None
+                    self.config_info[device] = None
 
-    def get_supported_protocols(self,device_name):
+    def get_supported_protocols(self, device_name):
         if self.is_device_valid(device_name):
             return self.config_info[device_name]['supported_protocols']
         return None
-    def get_version(self,device_name):
+
+    def get_version(self, device_name):
         if self.is_device_valid(device_name):
             return self.config_info[device_name]['version']
         return None
-    def is_device_valid(self,device_name):
+
+    def is_device_valid(self, device_name):
         return self.config_info[device_name] is not None
 
-    def is_protocol_supported(self,device_name,p):
+    def is_protocol_supported(self, device_name, p):
         """
         Provide 'p0', etc
         """
         return self.is_device_valid(device_name) and p in self.config_info[device_name]['supported_protocols']
 
-    def max_protocol_supported(self,device_name):
-        x=[int(x[1:]) for x in self.config_info[device_name]['supported_protocols']]
-        return 'p'+str(max(x))
+    def max_protocol_supported(self, device_name):
+        x = [int(x[1:]) for x in self.config_info[device_name]['supported_protocols']]
+        return 'p' + str(max(x))
 
     def pretty_print(self):
-        click.secho(' Currently Installed Firmware '.center(110,'#'),fg="cyan", bold=True)
+        click.secho(' Currently Installed Firmware '.center(110, '#'), fg="cyan", bold=True)
         for device in self.config_info:
             if self.use_device[device]:
-                click.secho('------------ %s ------------'%device.upper(),fg="white", bold=True)
+                click.secho('------------ %s ------------' % device.upper(), fg="white", bold=True)
                 if self.config_info[device]:
-                    click.echo('Installed Firmware: %s'%self.config_info[device]['board_info']['firmware_version'])
-                    x=" , ".join(["{}"]*len(self.config_info[device]['supported_protocols'])).format(*self.config_info[device]['supported_protocols'])
-                    click.echo('Installed Stretch Body supports protocols: '+x)
+                    click.echo('Installed Firmware: %s' % self.config_info[device]['board_info']['firmware_version'])
+                    x = " , ".join(["{}"] * len(self.config_info[device]['supported_protocols'])).format(
+                        *self.config_info[device]['supported_protocols'])
+                    click.echo('Installed Stretch Body supports protocols: ' + x)
                     if self.config_info[device]['installed_protocol_valid']:
-                        click.secho('Installed protocol %s : VALID'%self.config_info[device]['board_info']['protocol_version'])
+                        click.secho('Installed protocol %s : VALID' % self.config_info[device]['board_info'][
+                            'protocol_version'])
                     else:
-                        click.secho('Installed protocol %s : INVALID'%self.config_info[device]['board_info']['protocol_version'],fg="yellow")
+                        click.secho('Installed protocol %s : INVALID' % self.config_info[device]['board_info'][
+                            'protocol_version'], fg="yellow")
                 else:
                     click.secho('Device not found')
+
+
 # #####################################################################################################
 class AvailableFirmware():
-    def __init__(self,use_device):
-        self.use_device=use_device
-        self.repo=None
-        self.repo_path=None
+    def __init__(self, use_device):
+        self.use_device = use_device
+        self.repo = None
+        self.repo_path = None
         self.versions = {}
         for d in self.use_device:
             if self.use_device[d]:
-                self.versions[d]=[] #List of available versions for that device
+                self.versions[d] = []  # List of available versions for that device
         self.__clone_firmware_repo()
         self.__get_available_firmware_versions()
 
@@ -193,14 +210,15 @@ class AvailableFirmware():
         print('Collecting information...')
         self.repo_path = '/tmp/stretch_firmware_update'
         if not os.path.isdir(self.repo_path):
-            #print('Cloning latest version of Stretch Firmware to %s'% self.repo_path)
+            # print('Cloning latest version of Stretch Firmware to %s'% self.repo_path)
             try:
-                git.Repo.clone_from('https://github.com/hello-robot/stretch_firmware',  self.repo_path)
+                git.Repo.clone_from('https://github.com/hello-robot/stretch_firmware', self.repo_path)
             except git.GitCommandError as e:
                 if "could not resolve host" in e.stderr.lower():
                     print("ERROR: Unable to connect to Github. Check internet connection?", file=sys.stderr)
                 else:
-                    print("ERROR: Unable to clone stretch_firmware from Github into /tmp/stretch_firmware_update.", file=sys.stderr)
+                    print("ERROR: Unable to clone stretch_firmware from Github into /tmp/stretch_firmware_update.",
+                          file=sys.stderr)
                 sys.exit(1)
 
         sys.stdout.write('.')
@@ -223,13 +241,14 @@ class AvailableFirmware():
         sys.stdout.flush()
         print('\n')
 
-
     def pretty_print(self):
-        click.secho(' Currently Tagged Versions of Stretch Firmware on Master Branch '.center(110,'#'),fg="cyan", bold=True)
+        click.secho(' Currently Tagged Versions of Stretch Firmware on Master Branch '.center(110, '#'), fg="cyan",
+                    bold=True)
         for device_name in self.versions.keys():
-            click.secho('---- %s ----'%device_name.upper(), fg="white", bold=True)
+            click.secho('---- %s ----' % device_name.upper(), fg="white", bold=True)
             for v in self.versions[device_name]:
                 print(v)
+
     # python -m pip install gitpython
     # https://www.devdungeon.com/content/working-git-repositories-python
     def __get_available_firmware_versions(self):
@@ -239,129 +258,136 @@ class AvailableFirmware():
             v = FirmwareVersion(t.name)
             if v.valid:
                 for device_name in self.versions:
-                    if (v.device == 'Stepper' and device_name in ['hello-motor-lift','hello-motor-arm','hello-motor-left-wheel','hello-motor-right-wheel']) or\
-                        (v.device == 'Wacc' and device_name=='hello-wacc') or\
-                        (v.device == 'Pimu' and device_name=='hello-pimu'):
-                            self.versions[device_name].append(v)
+                    if (v.device == 'Stepper' and device_name in ['hello-motor-lift', 'hello-motor-arm',
+                                                                  'hello-motor-left-wheel',
+                                                                  'hello-motor-right-wheel']) or \
+                            (v.device == 'Wacc' and device_name == 'hello-wacc') or \
+                            (v.device == 'Pimu' and device_name == 'hello-pimu'):
+                        self.versions[device_name].append(v)
 
-
-
-    def get_most_recent_version(self,device_name,supported_protocols):
+    def get_most_recent_version(self, device_name, supported_protocols):
         """
         For the device and supported protocol versions (eg, '['p0','p1']'), return the most recent version (type FirmwareVersion)
         """
-        if len(self.versions[device_name])==0:
+        if len(self.versions[device_name]) == 0:
             return None
-        recent=None
-        s=[int(x[1:]) for x in supported_protocols ]
-        supported_versions=[]
+        recent = None
+        s = [int(x[1:]) for x in supported_protocols]
+        supported_versions = []
         for v in self.versions[device_name]:
             if v.protocol in s:
                 supported_versions.append(v)
         for sv in supported_versions:
-            if recent is None or sv>recent:
-                recent=sv
+            if recent is None or sv > recent:
+                recent = sv
         return recent
 
-
     def get_remote_branches(self):
-        branches=[]
+        branches = []
         print('Collecting information...')
         for ref in self.repo.git.branch('-r').split('\n'):
             sys.stdout.write('.')
             sys.stdout.flush()
             branches.append(ref)
         print('\n')
-        branches=[b.strip(' ') for b in branches if b.find('HEAD')==-1]
-        branches.remove('origin/master') #Move master to position 0
-        branches=['origin/master']+branches
+        branches = [b.strip(' ') for b in branches if b.find('HEAD') == -1]
+        branches.remove('origin/master')  # Move master to position 0
+        branches = ['origin/master'] + branches
         return branches
+
 
 # #####################################################################################################
 class RecommendedFirmware():
-    def __init__(self,use_device,installed=None,available=None):
-        self.use_device=use_device
+    def __init__(self, use_device, installed=None, available=None):
+        self.use_device = use_device
         self.fw_installed = InstalledFirmware(use_device) if installed is None else installed
-        self.fw_available= AvailableFirmware(use_device) if available is None else available
+        self.fw_available = AvailableFirmware(use_device) if available is None else available
         self.recommended = {}
         self.__get_recommend_updates()
 
     def __get_recommend_updates(self):
         for device_name in self.use_device.keys():
             if self.use_device[device_name]:
-                if self.fw_installed.is_device_valid(device_name): #Len 0 if device not found
-                    self.recommended[device_name]=self.fw_available.get_most_recent_version(device_name, self.fw_installed.get_supported_protocols(device_name))
+                if self.fw_installed.is_device_valid(device_name):  # Len 0 if device not found
+                    self.recommended[device_name] = self.fw_available.get_most_recent_version(device_name,
+                                                                                              self.fw_installed.get_supported_protocols(
+                                                                                                  device_name))
                 else:
-                    self.recommended[device_name]=None
+                    self.recommended[device_name] = None
 
     def pretty_print(self):
-        click.secho(' Recommended Firmware Updates '.center(110,'#'), fg="cyan",bold=True)
+        click.secho(' Recommended Firmware Updates '.center(110, '#'), fg="cyan", bold=True)
         print('\n')
-        click.secho('%s | %s | %s | %s ' % ('DEVICE'.ljust(25), 'INSTALLED'.ljust(25), 'RECOMMENDED'.ljust(25), 'ACTION'.ljust(25)), fg="cyan", bold=True)
-        click.secho('-'*110,fg="cyan", bold=True)
+        click.secho('%s | %s | %s | %s ' % (
+        'DEVICE'.ljust(25), 'INSTALLED'.ljust(25), 'RECOMMENDED'.ljust(25), 'ACTION'.ljust(25)), fg="cyan", bold=True)
+        click.secho('-' * 110, fg="cyan", bold=True)
 
         for device_name in self.recommended.keys():
-            dev_out=device_name.upper().ljust(25)
-            installed_out=''.ljust(25)
+            dev_out = device_name.upper().ljust(25)
+            installed_out = ''.ljust(25)
             rec_out = ''.ljust(25)
             action_out = ''.ljust(25)
             if not self.fw_installed.is_device_valid(device_name):
-                installed_out='No device available'.ljust(25)
+                installed_out = 'No device available'.ljust(25)
             else:
                 version = self.fw_installed.get_version(device_name)
-                installed_out=str(version).ljust(25)
-                if self.recommended[device_name]==None:
-                   rec_out='None (might be on dev branch)'.ljust(25)
+                installed_out = str(version).ljust(25)
+                if self.recommended[device_name] == None:
+                    rec_out = 'None (might be on dev branch)'.ljust(25)
                 else:
-                    rec_out=str(self.recommended[device_name]).ljust(25)
+                    rec_out = str(self.recommended[device_name]).ljust(25)
                     if self.recommended[device_name] > version:
-                        action_out='Upgrade recommended'.ljust(25)
+                        action_out = 'Upgrade recommended'.ljust(25)
                     elif self.recommended[device_name] < version:
-                        action_out='Downgrade recommended'.ljust(25)
+                        action_out = 'Downgrade recommended'.ljust(25)
                     else:
                         action_out = 'At most recent version'.ljust(25)
-            print('%s | %s | %s | %s ' %(dev_out,installed_out,rec_out,action_out))
-
+            print('%s | %s | %s | %s ' % (dev_out, installed_out, rec_out, action_out))
 
     def print_recommended_args(self):
-        dev_arg_map={'hello-pimu':' --pimu','hello-wacc':' --wacc','hello-motor-right-wheel':' --right_wheel',
-                     'hello-motor-left-wheel':' --left_wheel','hello-motor-lift':' --lift',
-                     'hello-motor-arm':' --arm'}
-        rec_args=''
+        dev_arg_map = {'hello-pimu': ' --pimu', 'hello-wacc': ' --wacc', 'hello-motor-right-wheel': ' --right_wheel',
+                       'hello-motor-left-wheel': ' --left_wheel', 'hello-motor-lift': ' --lift',
+                       'hello-motor-arm': ' --arm'}
+        rec_args = ''
         for device_name in self.recommended.keys():
             if self.fw_installed.is_device_valid(device_name):
                 version = self.fw_installed.get_version(device_name)
-                if self.recommended[device_name]!=None:
+                if self.recommended[device_name] != None:
                     if self.recommended[device_name] > version:
-                        rec_args=rec_args+dev_arg_map[device_name]
+                        rec_args = rec_args + dev_arg_map[device_name]
         if len(rec_args):
-            click.secho('\nRun recommended command: \nREx_firmware_updater.py --install %s'%rec_args,fg="green", bold=True)
+            click.secho('\nRun recommended command: \nREx_firmware_updater.py --install %s' % rec_args, fg="green",
+                        bold=True)
         else:
-            click.secho('\nFirmware upgrade not necessary',fg="green", bold=True)
+            click.secho('\nFirmware upgrade not necessary', fg="green", bold=True)
+
 
 # #####################################################################################################
 
-log_device=stretch_body.device.Device(req_params=False)
+log_device = stretch_body.device.Device(req_params=False)
 
-def user_msg_log(msg,user_display=True,fg=None,bg=None,bold=False):
+
+def user_msg_log(msg, user_display=True, fg=None, bg=None, bold=False):
     if user_display:
-        click.secho(str(msg),fg=fg, bg=bg,bold=bold)
+        click.secho(str(msg), fg=fg, bg=bg, bold=bold)
     log_device.logger.debug(str(msg))
 
+
 class FirmwareUpdater():
-    def __init__(self,use_device):
-        self.use_device=use_device
+    def __init__(self, use_device):
+        self.use_device = use_device
         self.fw_installed = InstalledFirmware(use_device)
         for device_name in self.use_device.keys():
-            self.use_device[device_name]=self.use_device[device_name] and self.fw_installed.is_device_valid(device_name)
-        self.fw_available= AvailableFirmware(use_device)
-        self.fw_recommended=RecommendedFirmware(use_device,self.fw_installed,self.fw_available)
-        self.target=self.fw_recommended.recommended.copy()
+            self.use_device[device_name] = self.use_device[device_name] and self.fw_installed.is_device_valid(
+                device_name)
+        self.fw_available = AvailableFirmware(use_device)
+        self.fw_recommended = RecommendedFirmware(use_device, self.fw_installed, self.fw_available)
+        self.target = self.fw_recommended.recommended.copy()
 
     def startup(self):
-        #if not self.__check_ubuntu_version():
+        # if not self.__check_ubuntu_version():
         #    print('Firmware Updater does not work on Ubuntu 20.04 currently. Please try again in Ubuntu 18.04')
-         #   return False
+        #   return False
         if self.__check_arduino_cli_install():
             self.__create_arduino_config_file()
             return True
@@ -382,26 +408,31 @@ class FirmwareUpdater():
             yaml.dump(arduino_config, yaml_file, default_flow_style=False)
 
     def __check_ubuntu_version(self):
-        res = Popen('cat /etc/lsb-release | grep DISTRIB_RELEASE', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read().strip(b'\n')
-        return res==b'DISTRIB_RELEASE=18.04'
-        
+        res = Popen('cat /etc/lsb-release | grep DISTRIB_RELEASE', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                    close_fds=True).stdout.read().strip(b'\n')
+        return res == b'DISTRIB_RELEASE=18.04'
+
     def __check_arduino_cli_install(self):
-        target_version=b'0.24.0'#0.18.3'
-        version='None'
-        res=Popen('arduino-cli version', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read()
-        do_install=False
-        if not(res[:11]==b'arduino-cli'):
-            do_install=True
+        target_version = b'0.31.0'  # 0.18.3'
+        version = 'None'
+        res = Popen('arduino-cli version', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
+                    close_fds=True).stdout.read()
+        do_install = False
+        if not (res[:11] == b'arduino-cli'):
+            do_install = True
         else:
-            version=res[res.find(b'Version:')+9:res.find(b' Commit')]
-            if version!=target_version:
-                do_install=True
+            version = res[res.find(b'Version:') + 9:res.find(b' Commit')]
+            if version != target_version:
+                do_install = True
         if do_install:
-            click.secho('WARNING:---------------------------------------------------------------------------------',fg="yellow", bold=True)
-            click.secho('WARNING: Compatible version of arduino_cli not installed. ',fg="yellow", bold=True)
-            click.secho('Requires version %s. Installed version of %s'%(target_version,version))
+            click.secho('WARNING:---------------------------------------------------------------------------------',
+                        fg="yellow", bold=True)
+            click.secho('WARNING: Compatible version of arduino_cli not installed. ', fg="yellow", bold=True)
+            click.secho('Requires version %s. Installed version of %s' % (target_version, version))
             if click.confirm('Install now?'):
-                os.system('curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh -s %s'%target_version.decode('utf-8'))
+                os.system(
+                    'curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh -s %s' % target_version.decode(
+                        'utf-8'))
                 os.system('arduino-cli config init')
                 os.system('arduino-cli core install arduino:samd@1.6.21')
                 return True
@@ -410,19 +441,19 @@ class FirmwareUpdater():
         return True
 
     def pretty_print_target(self):
-        click.secho(' UPDATING FIRMWARE TO... '.center(110,'#'), fg="cyan", bold=True)
-        for device_name in self.target.keys():
+        click.secho(' UPDATING FIRMWARE TO... '.center(110, '#'), fg="cyan", bold=True)
+        for device_name in self.target:
             if self.use_device[device_name]:
                 if not self.fw_installed.is_device_valid(device_name):
                     print('%s | No target available' % device_name.upper().ljust(25))
                 else:
-                    v_curr=self.fw_installed.get_version(device_name)
-                    v_targ=self.target[device_name]
+                    v_curr = self.fw_installed.get_version(device_name)
+                    v_targ = self.target[device_name]
                     if v_targ is None:
                         rec = 'No target available'
                     elif v_curr > v_targ:
                         rec = 'Downgrading to %s' % self.target[device_name]
-                    elif v_curr<v_targ:
+                    elif v_curr < v_targ:
                         rec = 'Upgrading to %s' % self.target[device_name]
                     else:
                         rec = 'Reinstalling %s' % self.target[device_name]
@@ -430,78 +461,82 @@ class FirmwareUpdater():
 
     def print_upload_warning(self):
         click.secho('------------------------------------------------', fg="yellow", bold=True)
-        click.secho('WARNING: (1) Updating robot firmware should only be done by experienced users', fg="yellow", bold=True)
+        click.secho('WARNING: (1) Updating robot firmware should only be done by experienced users', fg="yellow",
+                    bold=True)
         click.secho('WARNING: (2) Do not have other robot processes running during update', fg="yellow", bold=True)
         click.secho('WARNING: (3) Leave robot powered on during update', fg="yellow", bold=True)
         if self.use_device['hello-motor-lift']:
             click.secho('WARNING: (4) Ensure Lift has support clamp in place', fg="yellow", bold=True)
-            click.secho('WARNING: (5) Lift may make a loud noise during programming. This is normal.', fg="yellow", bold=True)
+            click.secho('WARNING: (5) Lift may make a loud noise during programming. This is normal.', fg="yellow",
+                        bold=True)
         click.secho('------------------------------------------------', fg="yellow", bold=True)
 
-
-    def do_update(self,no_prompts=False,repo_path=None,verbose=False):
+    def do_update(self, no_prompts=False, repo_path=None, verbose=False):
         # Return True if system was upgraded
         # Return False if system was not upgraded / error happened
-        self.num_update=0
+        self.num_update = 0
 
-        #Count how many updates doing
-        for device_name in self.target.keys():
+        # Count how many updates doing
+        for device_name in self.target:
             if self.fw_installed.is_device_valid(device_name) and self.target[device_name] is not None:
-                self.num_update=self.num_update+1
+                self.num_update = self.num_update + 1
 
         self.pretty_print_target()
 
         if not self.num_update:
-            click.secho('System is up to date. No updates to be done', fg="yellow",bold=True)
+            click.secho('System is up to date. No updates to be done', fg="yellow", bold=True)
             return False
         self.print_upload_warning()
-        self.fw_updated={}
+        self.fw_updated = {}
         if no_prompts or click.confirm('Proceed with update??'):
-            for device_name in self.target.keys():
-                self.fw_updated[device_name]=False
+            for device_name in self.target:
+                self.fw_updated[device_name] = False
                 if self.target[device_name] is not None:
-                    self.fw_updated[device_name]=self.flash_firmware_update(device_name,self.target[device_name].to_string(),repo_path=repo_path,verbose=verbose)
+                    self.fw_updated[device_name] = self.flash_firmware_update(device_name,
+                                                                              self.target[device_name].to_string(),
+                                                                              repo_path=repo_path, verbose=verbose)
                     if not self.fw_updated[device_name]:
                         return False
-            click.secho('---- Firmware Update Complete!', fg="cyan",bold=True)
-            success=self.post_firmware_update()
+            click.secho('---- Firmware Update Complete!', fg="cyan", bold=True)
+            success = True #self.post_firmware_update()
             return success
         return True
 
-    def do_update_to(self,verbose=False, no_prompts=False):
+    def do_update_to(self, verbose=False, no_prompts=False):
         # Return True if system was upgraded
         # Return False if system was not upgraded / error happened
-        click.secho(' Select target firmware versions '.center(60,'#'), fg="cyan", bold=True)
-        for device_name in self.fw_recommended.recommended.keys():
+        click.secho(' Select target firmware versions '.center(60, '#'), fg="cyan", bold=True)
+        for device_name in self.fw_recommended.recommended:
             if self.use_device[device_name]:
-                vs=self.fw_available.versions[device_name]
+                vs = self.fw_available.versions[device_name]
                 if len(vs) and self.fw_recommended.recommended[device_name] is not None:
                     print('')
-                    click.secho('---------- %s [%s]-----------'%(device_name.upper(),str(self.fw_installed.get_version(device_name))), fg="blue", bold=True)
-                    default_id=0
+                    click.secho('---------- %s [%s]-----------' % (
+                    device_name.upper(), str(self.fw_installed.get_version(device_name))), fg="blue", bold=True)
+                    default_id = 0
                     for i in range(len(vs)):
-                        if vs[i]==self.fw_recommended.recommended[device_name]:
-                            default_id=i
-                        print('%d: %s'%(i,vs[i]))
+                        if vs[i] == self.fw_recommended.recommended[device_name]:
+                            default_id = i
+                        print('%d: %s' % (i, vs[i]))
                     print('----------------------')
-                    vt=None
-                    while vt==None:
+                    vt = None
+                    while vt == None:
                         id = click.prompt('Please enter desired version id [Recommended]', default=default_id)
-                        if id>=0 and id<len(vs):
-                            vt=vs[id]
+                        if id >= 0 and id < len(vs):
+                            vt = vs[id]
                         else:
-                            click.secho('Invalid ID', fg="red" )
-                    print('Selected version %s for device %s'%(vt,device_name))
-                    self.target[device_name]=vt
+                            click.secho('Invalid ID', fg="red")
+                    print('Selected version %s for device %s' % (vt, device_name))
+                    self.target[device_name] = vt
         print('')
         print('')
         return self.do_update(verbose=verbose, no_prompts=no_prompts)
 
-    def do_update_to_path(self,path_name,verbose=False, no_prompts=False):
+    def do_update_to_path(self, path_name, verbose=False, no_prompts=False):
         # Burn the Head of the branch to each board regardless of what is currently installed
         click.secho('>>> Flashing firmware from path %s ' % path_name, fg="cyan", bold=True)
         # Check that version of target path is compatible
-        for device_name in self.target.keys():
+        for device_name in self.target:
             if self.use_device[device_name]:
                 sketch_name = self.get_sketch_name(device_name)
                 target_version = self.get_firmware_version_from_path(sketch_name, path_name)
@@ -511,8 +546,11 @@ class FirmwareUpdater():
                 path_protocol = 'p' + str(target_version.protocol)
                 if not self.fw_installed.is_protocol_supported(device_name, path_protocol):
                     click.secho('---------------------------', fg="yellow")
-                    click.secho('Target firmware path of %s is incompatible with installed Stretch Body for device %s' % (path_name, device_name), fg="yellow")
-                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(*self.fw_installed.get_supported_protocols(device_name))
+                    click.secho(
+                        'Target firmware path of %s is incompatible with installed Stretch Body for device %s' % (
+                        path_name, device_name), fg="yellow")
+                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(
+                        *self.fw_installed.get_supported_protocols(device_name))
                     click.secho('Installed Stretch Body supports protocols %s' % x, fg="yellow")
                     click.secho('Target path supports protocol %s' % path_protocol, fg="yellow")
                     if path_protocol > self.fw_installed.max_protocol_supported(device_name):
@@ -520,54 +558,56 @@ class FirmwareUpdater():
                     else:
                         click.secho('Downgrade Stretch Body first...', fg="yellow")
                     return False
-        repo_path=path_name[:path_name.rfind('arduino')]
-        return self.do_update(repo_path=repo_path,verbose=verbose,no_prompts=no_prompts)
+        repo_path = path_name[:path_name.rfind('arduino')]
+        return self.do_update(repo_path=repo_path, verbose=verbose, no_prompts=no_prompts)
 
-    def do_update_to_branch(self,verbose=False, no_prompts=False):
+    def do_update_to_branch(self, verbose=False, no_prompts=False):
         # Return True if system was upgraded
         # Return False if system was not upgraded / error happened
-        click.secho(' Select target branch '.center(60,'#'), fg="cyan", bold=True)
-        branches=self.fw_available.get_remote_branches()
+        click.secho(' Select target branch '.center(60, '#'), fg="cyan", bold=True)
+        branches = self.fw_available.get_remote_branches()
         for id in range(len(branches)):
             print('%d: %s' % (id, branches[id]))
         print('')
-        branch_name=None
+        branch_name = None
         while branch_name == None:
             try:
-                id = click.prompt('Please enter desired branch id',default=0)
+                id = click.prompt('Please enter desired branch id', default=0)
             except click.exceptions.Abort:
                 return False
             if id >= 0 and id < len(branches):
-                branch_name=branches[id]
+                branch_name = branches[id]
             else:
                 click.secho('Invalid ID', fg="red")
-        print('Selected branch %s'%branch_name )
-        #Check that version of target branch is compatible
-        for device_name in self.target.keys():
+        print('Selected branch %s' % branch_name)
+        # Check that version of target branch is compatible
+        for device_name in self.target:
             if self.use_device[device_name]:
-                sketch_name=self.get_sketch_name(device_name)
-                target_version=self.get_firmware_version_from_git(sketch_name, branch_name)
-                self.target[device_name]=target_version
-                git_protocol = 'p'+str(target_version.protocol)
-                if not self.fw_installed.is_protocol_supported(device_name,git_protocol):
+                sketch_name = self.get_sketch_name(device_name)
+                target_version = self.get_firmware_version_from_git(sketch_name, branch_name)
+                self.target[device_name] = target_version
+                git_protocol = 'p' + str(target_version.protocol)
+                if not self.fw_installed.is_protocol_supported(device_name, git_protocol):
                     click.secho('---------------------------', fg="yellow")
-                    click.secho('Target firmware branch of %s is incompatible with installed Stretch Body for device %s'%(branch_name,device_name),fg="yellow")
-                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(*self.fw_installed.get_supported_protocols(device_name))
-                    click.secho('Installed Stretch Body supports protocols %s'%x,fg="yellow")
-                    click.secho('Target branch supports protocol %s'%git_protocol,fg="yellow")
-                    if git_protocol>self.fw_installed.max_protocol_supported(device_name):
-                        click.secho('Upgrade Stretch Body first...',fg="yellow")
+                    click.secho(
+                        'Target firmware branch of %s is incompatible with installed Stretch Body for device %s' % (
+                        branch_name, device_name), fg="yellow")
+                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(
+                        *self.fw_installed.get_supported_protocols(device_name))
+                    click.secho('Installed Stretch Body supports protocols %s' % x, fg="yellow")
+                    click.secho('Target branch supports protocol %s' % git_protocol, fg="yellow")
+                    if git_protocol > self.fw_installed.max_protocol_supported(device_name):
+                        click.secho('Upgrade Stretch Body first...', fg="yellow")
                     else:
-                        click.secho('Downgrade Stretch Body first...',fg="yellow")
+                        click.secho('Downgrade Stretch Body first...', fg="yellow")
                     return False
-        return self.do_update(verbose=verbose,no_prompts=no_prompts)
+        return self.do_update(verbose=verbose, no_prompts=no_prompts)
 
-
-    def flash_stepper_calibration(self,device_name):
+    def flash_stepper_calibration(self, device_name):
         if device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-left-wheel':
-            click.secho(' Flashing Stepper Calibration: %s '.center(110,'#') % device_name, fg="cyan",bold=True)
+            click.secho(' Flashing Stepper Calibration: %s '.center(110, '#') % device_name, fg="cyan", bold=True)
             if not self.wait_on_device(device_name):
-                click.secho('Device %s failed to return to bus' % device_name, fg="red",bold=True)
+                click.secho('Device %s failed to return to bus' % device_name, fg="red", bold=True)
                 return False
             time.sleep(1.0)
             motor = stretch_body.stepper.Stepper('/dev/' + device_name)
@@ -594,7 +634,6 @@ class FirmwareUpdater():
                 self.wait_on_device(device_name)
                 print('Successful return of device to bus.')
         return True
-
 
     def post_firmware_update(self):
         #Return True if no errors
@@ -789,11 +828,13 @@ class FirmwareUpdater():
             compile_command = 'arduino-cli compile --config-file %s --fqbn hello-robot:samd:%s %s/arduino/%s'%(config_file,sketch_name,src_path,sketch_name)
             user_msg_log(compile_command,user_display=verbose)
             c=Popen(compile_command, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
-            cc = c.split(b'\n')
+            if type(c)==bytes:
+                c=c.decode("utf-8")
+            cc = c.split('\n')
             user_msg_log(c, user_display=verbose)
 
             # In version 0.18.x the last line after compile is: Sketch uses xxx bytes (58%) of program storage space. Maximum is yyy bytes.
-            #In version 0.24.x this is now on line 0.
+            #In version 0.24.x +this is now on line 0.
             #Need a more robust way to determine successful compile. Works for now.
             success=str(cc[0]).find('Sketch uses')!=-1
             if not success:
@@ -805,20 +846,21 @@ class FirmwareUpdater():
             upload_command = 'arduino-cli upload  --config-file %s -p /dev/%s --fqbn hello-robot:samd:%s %s/arduino/%s' % (config_file, port_name, sketch_name, src_path,sketch_name)
             user_msg_log(upload_command,user_display=verbose)
             u = Popen(upload_command, shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
-            uu = u.split(b'\n')
+            if type(u) == bytes:
+                u=u.decode('utf-8')
+            uu = u.split('\n')
             user_msg_log(u, user_display=False)
             if verbose:
                 print(upload_command)
                 # Pretty print the result
                 for l in uu:
-                    k = l.split(b'\r')
+                    k = l.split('\r')
                     if len(k) == 1:
-                        print(k[0].decode('utf-8'))
+                        print(k[0])
                     else:
                         for m in k:
-                            print(m.decode('utf-8'))
-
-            success = uu[-1] == b'CPU reset.'
+                            print(m)
+            success = uu[-1] == 'CPU reset.'
             if not success:
                 print('Firmware flash. Failed to upload to %s' % (port_name))
                 return False

--- a/python/stretch_factory/firmware_updater.py
+++ b/python/stretch_factory/firmware_updater.py
@@ -3,7 +3,6 @@
 import click
 import os
 from subprocess import Popen, PIPE
-import git
 import stretch_body.stepper
 import stretch_body.pimu
 import stretch_body.wacc
@@ -12,378 +11,25 @@ import yaml
 import time
 import sys
 import stretch_body.device
-from stretch_factory.device_mgmt import StretchDeviceMgmt
+
 import stretch_body.hello_utils
-import stretch_factory.hello_device_utils as hdu
 import shlex
-
-# #####################################################################################################
-class FirmwareVersion():
-    """
-    Manage comparision of firmware versions
-    """
-
-    def __init__(self, version_str):
-        self.device = 'NONE'
-        self.major = 0
-        self.minor = 0
-        self.bugfix = 0
-        self.protocol = 0
-        self.valid = False
-        self.from_string(version_str)
-
-    def __str__(self):
-        return self.to_string()
-
-    def to_string(self):
-        """
-        Version is represented as Stepper.v0.0.1p0 for example
-        """
-        return self.device + '.v' + str(self.major) + '.' + str(self.minor) + '.' + str(self.bugfix) + 'p' + str(
-            self.protocol)
-
-    def __gt__(self, other):
-        if not self.valid or not other.valid:
-            return False
-        if self.protocol > other.protocol:
-            return True
-        if self.protocol < other.protocol:
-            return False
-        if self.major > other.major:
-            return True
-        if self.minor > other.minor:
-            return True
-        if self.bugfix > other.bugfix:
-            return True
-        return False
-
-    def __lt__(self, other):
-        if not self.valid or not other.valid:
-            return False
-        if self.protocol < other.protocol:
-            return True
-        if self.protocol > other.protocol:
-            return False
-        if self.major < other.major:
-            return True
-        if self.minor < other.minor:
-            return True
-        if self.bugfix < other.bugfix:
-            return True
-        return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __eq__(self, other):
-        if not other or not self.valid or not other.valid:
-            return False
-        return self.major == other.major and self.minor == other.minor and self.bugfix == other.bugfix and self.protocol == other.protocol
-
-    def same_device(self, d):
-        return d == self.device
-
-    def from_string(self, x):
-        # X is of form 'Stepper.v0.0.1p0'
-        try:
-            xl = x.split('.')
-            if len(xl) != 4:
-                raise Exception('Invalid version len')
-            device = xl[0]
-            if not (device == 'Stepper' or device == 'Wacc' or device == 'Pimu'):
-                raise Exception('Invalid device name ')
-            major = int(xl[1][1:])
-            minor = int(xl[2])
-            bugfix = int(xl[3][0:xl[3].find('p')])
-            protocol = int(xl[3][(xl[3].find('p') + 1):])
-            self.device = device
-            self.major = major
-            self.minor = minor
-            self.bugfix = bugfix
-            self.protocol = protocol
-            self.valid = True
-        except(ValueError, Exception):
-            print('Invalid version format in tag: %s' % x)
-
-
-# #####################################################################################################
-class InstalledFirmware():
-    """
-    Pull the current installed firmware off the robot uCs
-    Build config_info of form:
-    {'hello-motor-arm': {'board_info': {'board_version': u'Stepper.Irma.V1',
-       'firmware_version': u'Stepper.v0.0.1p1',
-       'protocol_version': u'p1'},
-      'installed_protocol_valid': True,
-      'supported_protocols': ['p0', 'p1']}}
-    """
-
-    def __init__(self, use_device):
-        """
-        use_device has form of:
-        {'hello-motor-lift': True, 'hello-motor-arm': True, 'hello-motor-right-wheel': True, 'hello-motor-left-wheel': True, 'hello-pimu': True, 'hello-wacc': True}
-        """
-        self.use_device = use_device
-        self.config_info = {'hello-motor-lift': None, 'hello-motor-arm': None, 'hello-motor-left-wheel': None,
-                            'hello-motor-right-wheel': None, 'hello-pimu': None, 'hello-wacc': None}
-        for device in self.use_device.keys():
-            if self.use_device[device]:
-                if device == 'hello-wacc':
-                    dd = stretch_body.wacc.Wacc()
-                elif device == 'hello-pimu':
-                    dd = stretch_body.pimu.Pimu()
-                else:
-                    dd = stretch_body.stepper.Stepper('/dev/' + device)
-                dd.startup()
-                if dd.board_info['firmware_version'] is not None:  # Was able to pull board info from device
-                    self.config_info[device] = {}
-                    self.config_info[device]['board_info'] = dd.board_info.copy()
-                    try:
-                        self.config_info[device]['supported_protocols'] = dd.supported_protocols.keys()
-                    except AttributeError:
-                        # Older versions of stretch body used a different represenation
-                        self.config_info[device]['supported_protocols'] = [dd.valid_firmware_protocol]
-                    self.config_info[device]['installed_protocol_valid'] = (
-                                dd.board_info['protocol_version'] in self.config_info[device]['supported_protocols'])
-                    self.config_info[device]['version'] = FirmwareVersion(
-                        self.config_info[device]['board_info']['firmware_version'])
-                    dd.stop()
-                else:
-                    self.config_info[device] = None
-
-    def get_supported_protocols(self, device_name):
-        if self.is_device_valid(device_name):
-            return self.config_info[device_name]['supported_protocols']
-        return None
-
-    def get_version(self, device_name):
-        if self.is_device_valid(device_name):
-            return self.config_info[device_name]['version']
-        return None
-
-    def is_device_valid(self, device_name):
-        return self.config_info[device_name] is not None
-
-    def is_protocol_supported(self, device_name, p):
-        """
-        Provide 'p0', etc
-        """
-        return self.is_device_valid(device_name) and p in self.config_info[device_name]['supported_protocols']
-
-    def max_protocol_supported(self, device_name):
-        x = [int(x[1:]) for x in self.config_info[device_name]['supported_protocols']]
-        return 'p' + str(max(x))
-
-    def pretty_print(self):
-        click.secho(' Currently Installed Firmware '.center(110, '#'), fg="cyan", bold=True)
-        for device in self.config_info:
-            if self.use_device[device]:
-                click.secho('------------ %s ------------' % device.upper(), fg="white", bold=True)
-                if self.config_info[device]:
-                    click.echo('Installed Firmware: %s' % self.config_info[device]['board_info']['firmware_version'])
-                    x = " , ".join(["{}"] * len(self.config_info[device]['supported_protocols'])).format(
-                        *self.config_info[device]['supported_protocols'])
-                    click.echo('Installed Stretch Body supports protocols: ' + x)
-                    if self.config_info[device]['installed_protocol_valid']:
-                        click.secho('Installed protocol %s : VALID' % self.config_info[device]['board_info'][
-                            'protocol_version'])
-                    else:
-                        click.secho('Installed protocol %s : INVALID' % self.config_info[device]['board_info'][
-                            'protocol_version'], fg="yellow")
-                else:
-                    click.secho('Device not found')
-
-
-# #####################################################################################################
-class AvailableFirmware():
-    def __init__(self, use_device):
-        self.use_device = use_device
-        self.repo = None
-        self.repo_path = None
-        self.versions = {}
-        for d in self.use_device:
-            if self.use_device[d]:
-                self.versions[d] = []  # List of available versions for that device
-        self.__clone_firmware_repo()
-        self.__get_available_firmware_versions()
-
-    def __clone_firmware_repo(self):
-        print('Collecting information...')
-        self.repo_path = '/tmp/stretch_firmware_update'
-        if not os.path.isdir(self.repo_path):
-            # print('Cloning latest version of Stretch Firmware to %s'% self.repo_path)
-            try:
-                git.Repo.clone_from('https://github.com/hello-robot/stretch_firmware', self.repo_path)
-            except git.GitCommandError as e:
-                if "could not resolve host" in e.stderr.lower():
-                    print("ERROR: Unable to connect to Github. Check internet connection?", file=sys.stderr)
-                else:
-                    print("ERROR: Unable to clone stretch_firmware from Github into /tmp/stretch_firmware_update.",
-                          file=sys.stderr)
-                sys.exit(1)
-
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        self.repo = git.Repo(self.repo_path)
-        os.chdir(self.repo_path)
-
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        os.system('git checkout master >/dev/null 2>&1')
-
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        os.system('git fetch --tags >/dev/null 2>&1 ')
-
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        os.system('git pull >/dev/null 2>&1 ')
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        print('\n')
-
-    def pretty_print(self):
-        click.secho(' Currently Tagged Versions of Stretch Firmware on Master Branch '.center(110, '#'), fg="cyan",
-                    bold=True)
-        for device_name in self.versions.keys():
-            click.secho('---- %s ----' % device_name.upper(), fg="white", bold=True)
-            for v in self.versions[device_name]:
-                print(v)
-
-    # python -m pip install gitpython
-    # https://www.devdungeon.com/content/working-git-repositories-python
-    def __get_available_firmware_versions(self):
-        if self.repo is None:
-            return
-        for t in self.repo.tags:
-            v = FirmwareVersion(t.name)
-            if v.valid:
-                for device_name in self.versions:
-                    if (v.device == 'Stepper' and device_name in ['hello-motor-lift', 'hello-motor-arm',
-                                                                  'hello-motor-left-wheel',
-                                                                  'hello-motor-right-wheel']) or \
-                            (v.device == 'Wacc' and device_name == 'hello-wacc') or \
-                            (v.device == 'Pimu' and device_name == 'hello-pimu'):
-                        self.versions[device_name].append(v)
-
-    def get_most_recent_version(self, device_name, supported_protocols):
-        """
-        For the device and supported protocol versions (eg, '['p0','p1']'), return the most recent version (type FirmwareVersion)
-        """
-        if len(self.versions[device_name]) == 0:
-            return None
-        recent = None
-        s = [int(x[1:]) for x in supported_protocols]
-        supported_versions = []
-        for v in self.versions[device_name]:
-            if v.protocol in s:
-                supported_versions.append(v)
-        for sv in supported_versions:
-            if recent is None or sv > recent:
-                recent = sv
-        return recent
-
-    def get_remote_branches(self):
-        branches = []
-        print('Collecting information...')
-        for ref in self.repo.git.branch('-r').split('\n'):
-            sys.stdout.write('.')
-            sys.stdout.flush()
-            branches.append(ref)
-        print('\n')
-        branches = [b.strip(' ') for b in branches if b.find('HEAD') == -1]
-        branches.remove('origin/master')  # Move master to position 0
-        branches = ['origin/master'] + branches
-        return branches
-
-
-# #####################################################################################################
-class RecommendedFirmware():
-    def __init__(self, use_device, installed=None, available=None):
-        self.use_device = use_device
-        self.fw_installed = InstalledFirmware(use_device) if installed is None else installed
-        self.fw_available = AvailableFirmware(use_device) if available is None else available
-        self.recommended = {}
-        self.__get_recommend_updates()
-
-    def __get_recommend_updates(self):
-        for device_name in self.use_device.keys():
-            if self.use_device[device_name]:
-                if self.fw_installed.is_device_valid(device_name):  # Len 0 if device not found
-                    self.recommended[device_name] = self.fw_available.get_most_recent_version(device_name,
-                                                                                              self.fw_installed.get_supported_protocols(
-                                                                                                  device_name))
-                else:
-                    self.recommended[device_name] = None
-
-    def pretty_print(self):
-        click.secho(' Recommended Firmware Updates '.center(110, '#'), fg="cyan", bold=True)
-        print('\n')
-        click.secho('%s | %s | %s | %s ' % (
-        'DEVICE'.ljust(25), 'INSTALLED'.ljust(25), 'RECOMMENDED'.ljust(25), 'ACTION'.ljust(25)), fg="cyan", bold=True)
-        click.secho('-' * 110, fg="cyan", bold=True)
-
-        for device_name in self.recommended.keys():
-            dev_out = device_name.upper().ljust(25)
-            installed_out = ''.ljust(25)
-            rec_out = ''.ljust(25)
-            action_out = ''.ljust(25)
-            if not self.fw_installed.is_device_valid(device_name):
-                installed_out = 'No device available'.ljust(25)
-            else:
-                version = self.fw_installed.get_version(device_name)
-                installed_out = str(version).ljust(25)
-                if self.recommended[device_name] == None:
-                    rec_out = 'None (might be on dev branch)'.ljust(25)
-                else:
-                    rec_out = str(self.recommended[device_name]).ljust(25)
-                    if self.recommended[device_name] > version:
-                        action_out = 'Upgrade recommended'.ljust(25)
-                    elif self.recommended[device_name] < version:
-                        action_out = 'Downgrade recommended'.ljust(25)
-                    else:
-                        action_out = 'At most recent version'.ljust(25)
-            print('%s | %s | %s | %s ' % (dev_out, installed_out, rec_out, action_out))
-
-    def print_recommended_args(self):
-        dev_arg_map = {'hello-pimu': ' --pimu', 'hello-wacc': ' --wacc', 'hello-motor-right-wheel': ' --right_wheel',
-                       'hello-motor-left-wheel': ' --left_wheel', 'hello-motor-lift': ' --lift',
-                       'hello-motor-arm': ' --arm'}
-        rec_args = ''
-        for device_name in self.recommended.keys():
-            if self.fw_installed.is_device_valid(device_name):
-                version = self.fw_installed.get_version(device_name)
-                if self.recommended[device_name] != None:
-                    if self.recommended[device_name] > version:
-                        rec_args = rec_args + dev_arg_map[device_name]
-        if len(rec_args):
-            click.secho('\nRun recommended command: \nREx_firmware_updater.py --install %s' % rec_args, fg="green",
-                        bold=True)
-        else:
-            click.secho('\nFirmware upgrade not necessary', fg="green", bold=True)
-
-
-# #####################################################################################################
-
-log_device = stretch_body.device.Device(req_params=False)
-
-
-def user_msg_log(msg, user_display=True, fg=None, bg=None, bold=False):
-    if user_display:
-        click.secho(str(msg), fg=fg, bg=bg, bold=bold)
-    log_device.logger.debug(str(msg))
-
+from stretch_factory.firmware_available import FirmwareAvailable
+from stretch_factory.firmware_recommended import FirmwareRecommended
+from stretch_factory.firmware_installed import FirmwareInstalled
+from stretch_factory.firmware_version import FirmwareVersion
+from stretch_factory.firmware_utils import *
 
 class FirmwareUpdater():
     def __init__(self, use_device):
         self.use_device = use_device
-        self.fw_installed = InstalledFirmware(use_device)
+        self.fw_installed = FirmwareInstalled(use_device)
         for device_name in self.use_device.keys():
-            self.use_device[device_name] = self.use_device[device_name] and self.fw_installed.is_device_valid(
-                device_name)
-        self.fw_available = AvailableFirmware(use_device)
-        self.fw_recommended = RecommendedFirmware(use_device, self.fw_installed, self.fw_available)
+            self.use_device[device_name] = self.use_device[device_name] and self.fw_installed.is_device_valid(device_name)
+        self.fw_available = FirmwareAvailable(use_device)
+        self.fw_recommended = FirmwareRecommended(use_device, self.fw_installed, self.fw_available)
         self.target = self.fw_recommended.recommended.copy()
+
 
     def startup(self):
         # if not self.__check_ubuntu_version():
@@ -393,6 +39,326 @@ class FirmwareUpdater():
             self.__create_arduino_config_file()
             return True
         return False
+
+# ########################################################################################################3
+    def get_update_to(self):
+        #Override self.target with user input
+        click.secho(' Select target firmware versions '.center(60, '#'), fg="cyan", bold=True)
+        for device_name in self.fw_recommended.recommended:
+            if self.use_device[device_name]:
+                vs = self.fw_available.versions[device_name]
+                if len(vs) and self.fw_recommended.recommended[device_name] is not None:
+                    print('')
+                    click.secho('---------- %s [%s]-----------' % (
+                        device_name.upper(), str(self.fw_installed.get_version(device_name))), fg="blue",
+                                bold=True)
+                    default_id = 0
+                    for i in range(len(vs)):
+                        if vs[i] == self.fw_recommended.recommended[device_name]:
+                            default_id = i
+                        print('%d: %s' % (i, vs[i]))
+                    print('----------------------')
+                    vt = None
+                    while vt == None:
+                        id = click.prompt('Please enter desired version id [Recommended]', default=default_id)
+                        if id >= 0 and id < len(vs):
+                            vt = vs[id]
+                        else:
+                            click.secho('Invalid ID', fg="red")
+                    print('Selected version %s for device %s' % (vt, device_name))
+                    self.target[device_name] = vt
+        print('')
+        print('')
+
+    def get_update_to_path(self, path_name):
+        # Burn the Head of the branch to each board regardless of what is currently installed
+        click.secho('>>> Flashing firmware from path %s ' % path_name, fg="cyan", bold=True)
+        # Check that version of target path is compatible
+        for device_name in self.target:
+            if self.use_device[device_name]:
+                sketch_name = self.get_sketch_name(device_name)
+                target_version = self.get_firmware_version_from_path(sketch_name, path_name)
+                if target_version is None:
+                    return False
+                self.target[device_name] = target_version
+                path_protocol = 'p' + str(target_version.protocol)
+                if not self.fw_installed.is_protocol_supported(device_name, path_protocol):
+                    click.secho('---------------------------', fg="yellow")
+                    click.secho(
+                        'Target firmware path of %s is incompatible with installed Stretch Body for device %s' % (
+                        path_name, device_name), fg="yellow")
+                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(
+                        *self.fw_installed.get_supported_protocols(device_name))
+                    click.secho('Installed Stretch Body supports protocols %s' % x, fg="yellow")
+                    click.secho('Target path supports protocol %s' % path_protocol, fg="yellow")
+                    if path_protocol > self.fw_installed.max_protocol_supported(device_name):
+                        click.secho('Upgrade Stretch Body first...', fg="yellow")
+                    else:
+                        click.secho('Downgrade Stretch Body first...', fg="yellow")
+                    return False
+        self.repo_path = path_name[:path_name.rfind('arduino')]
+        return True
+
+    # ########################################################################################################3
+    def run(self,args):
+        #First construct the updater state dictionary
+        self.update_state = self.load_update_state()
+        if args.do_resume and not self.update_state:
+            click.secho('WARNING: A previous firmware update is not available. Unable to resume', fg="yellow",bold=True)
+            return False
+
+        if self.update_state and not args.do_resume:
+            click.secho('WARNING: A previous firmware update is incomplete', fg="yellow", bold=True)
+            click.secho('WARNING: Run REx_firmware_udpater.py --resume', fg="yellow", bold=True)
+            click.secho('WARNING: Or delete file /tmp/firmware_updater_state.yaml and try again.', fg="yellow",bold=True)
+            return False
+
+        if not self.update_state: #Starting on a new update
+            self.update_state = {}
+            self.update_state['verbose'] = args.verbose
+            self.update_state['no_prompts'] = args.no_prompts
+            self.update_state['verbose'] = args.verbose
+            self.update_state['install_version'] = args.install_version
+
+            if args.install_path:
+                if args.install_path[0] != '/':
+                    self.update_state['install_path']=os.getcwd() + '/' + args.install_path
+                else:
+                    self.update_state['install_path']=args.install_path
+            for device_name in self.target:
+                if self.target[device_name] is not None:
+                    self.update_state[device_name] = {'flash': False,
+                                                      'return_to_bus': False,
+                                                      'version_validate':False,
+                                                      'calibration_flash': False}
+
+
+            # if args.install_version:
+            #     self.get_update_to()
+            #
+            # if args.install_path:
+            #     self.get_update_to_path(self.update_state['install_path'])
+
+            self.update_state['target'] = self.target.copy()
+
+
+            # Count how many updates doing
+            self.num_update = 0
+            for device_name in self.target:
+                if self.fw_installed.is_device_valid(device_name) and self.target[device_name] is not None:
+                    self.num_update = self.num_update + 1
+            self.pretty_print_target()
+            if not self.num_update:
+                click.secho('System is up to date. No updates to be done', fg="yellow", bold=True)
+                return False
+            self.print_upload_warning()
+
+        tag = None
+        repo_path=None
+
+        self.pretty_print_update_state()
+
+        #Advance the state machine
+        if args.no_prompts or click.confirm('Proceed with update??'):
+            #update_state is now filled out. Advance the states of all targets
+
+            #Flash all devices
+            for d in self.update_state['target']:
+                if d is not None and not self.update_state[d]['flash']:
+                    self.update_state[d]['flash']=self.do_device_flash(d,tag,repo_path,args.verbose)
+
+            if not self.all_pass('flash'):
+                click.secho('WARNING: Not all devices flashed successfully', fg="yellow", bold=True)
+                click.secho('WARNING: Reboot machine.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py - -resume')
+                return False
+
+            for d in self.update_state['target']:
+                if d is not None and not self.update_state[d]['return_to_bus']:
+                    self.update_state[d]['return_to_bus']=self.wait_on_return_to_bus(d)
+
+            if not self.all_pass('return_to_bus'):
+                click.secho('WARNING: Not all devices returned to bus successfully', fg="yellow", bold=True)
+                click.secho('WARNING: Reboot machine.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py - -resume')
+                return False
+
+            for d in self.update_state['target']:
+                if d is not None and not self.update_state[d]['version_validate']:
+                    self.update_state[d]['version_validate'] = self.verify_firmware_version(d)
+
+            if not self.all_pass('verify_firmware_version'):
+                click.secho('WARNING: Not all devices have updated to target firmware version', fg="yellow", bold=True)
+                click.secho('WARNING: Reboot machine.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py - -resume')
+                return False
+
+            for d in self.update_state['target']:
+                if d is not None and not self.update_state[d]['calibration_flash']:
+                    self.update_state[d]['calibration_flash'] = self.calibration_flash(d)
+
+
+            if 1:#all_success:
+                print('')
+                click.secho('----------------- Congratulations! ---------------.', fg="green", bold=True)
+                click.secho('No issues encountered. Firmware update successful.', fg="green", bold=True)
+
+    def pretty_print_update_state(self):
+        pass
+
+    def all_pass(self,state_name):
+        all_pass=True
+        for d in self.update_state['target']:
+            if d is not None:
+                all_pass=all_pass and self.update_state[d][state_name]
+
+# ########################################################################################################################
+    def wait_on_return_to_bus(self,device_name):
+        click.secho('Checking that device %s returned to bus '%device_name)
+        print('It may take several minutes to appear on the USB bus.' )
+        ts = time.time()
+        found = False
+        for i in range(30):
+            if not self.wait_on_device(device_name, timeout=10.0):
+                print('Trying again: %d\n' % i)
+                # Bit of a hack.Sometimes after a firmware flash the device
+                # Doesn't fully present on the USB bus with a serial No for Udev to find
+                # In does present as an 'Arduino Zero' product. This will attempt to reset it
+                # and re-present to the bus
+                # time.sleep(1.0)
+                # os.system('usbreset \"Arduino Zero\"')
+                # time.sleep(1.0)
+                print('')
+            else:
+                found = True
+                break
+        if not found:
+            click.secho('Device %s failed to return to bus after %f seconds.' % (device_name, time.time() - ts),fg="yellow", bold=True)
+            return False
+        else:
+            click.secho('Device %s returned to bus after %f seconds.' % (device_name, time.time() - ts),fg="green", bold=True)
+        return True
+
+# ########################################################################################################################
+#     def foo(self):
+#         all_success = all_success and self.verify_firmware_version(device_name)
+#         print('')
+#         print('')
+#                 # NOTE: Move to exceptions and single device flow, can track where in the flow it fails.
+#                 self.post_firmware_update(device_name)
+#
+#                 if len(no_return):
+#                     click.secho('Devices did not return to bus. Power cycle robot', fg="yellow", bold=True)
+#                     click.secho('Then run stretch_robot_system_check.py to confirm all devices present', fg="yellow",
+#                                 bold=True)
+#                     for device_name in no_stepper_return:
+#                         click.secho(
+#                             'Device %s requires calibration data to be written after power cycle.' % device_name,
+#                             fg="yellow", bold=True)
+#                         click.secho('After power cycle run: REx_stepper_calibration_YAML_to_flash.py %s' % device_name,
+#                                     fg="yellow", bold=True)
+#                     return False
+#
+#                 return all_success
+#         return True
+
+# ########################################################################################################################
+    def do_device_flash(self,device_name, tag,repo_path=None,verbose=False):
+        click.secho('-------- FIRMWARE FLASH %s | %s ------------'%(device_name,tag), fg="cyan", bold=True)
+        config_file = self.fw_available.repo_path + '/arduino-cli.yaml'
+
+        user_msg_log('Config: '+str(config_file), user_display=verbose)
+        user_msg_log('Repo: '+str(repo_path), user_display=verbose)
+
+        sketch_name=None
+        if device_name == 'hello-motor-left-wheel' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift':
+            sketch_name = 'hello_stepper'
+        if device_name == 'hello-wacc':
+            sketch_name = 'hello_wacc'
+        if device_name == 'hello-pimu':
+            sketch_name = 'hello_pimu'
+
+        if sketch_name=='hello_stepper' and not self.does_stepper_have_encoder_calibration_YAML(device_name):
+            print('Encoder data has not been stored for %s and may be lost. Aborting firmware flash.'%device_name)
+            return False
+
+        print('Looking for device %s on bus' % device_name)
+        if not self.wait_on_device(device_name, timeout=5.0):
+            print('Failure: Device not on bus.')
+            return False
+        port_name = self.get_port_name(device_name)
+        user_msg_log('Device: %s Port: %s'%(device_name,port_name), user_display=verbose)
+        if port_name is not None and sketch_name is not None:
+
+            print('Starting programming. This will take about 5s...')
+            if repo_path is None:
+                os.chdir(self.fw_available.repo_path)
+                os.system('git checkout '+tag+'>/dev/null 2>&1')
+                src_path=self.fw_available.repo_path
+            else:
+                src_path=repo_path
+
+            compile_command = 'arduino-cli compile --config-file %s --fqbn hello-robot:samd:%s %s/arduino/%s'%(config_file,sketch_name,src_path,sketch_name)
+            user_msg_log(compile_command,user_display=verbose)
+            c=Popen(shlex.split(compile_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
+            if type(c)==bytes:
+                c=c.decode("utf-8")
+            cc = c.split('\n')
+            user_msg_log(c, user_display=verbose)
+
+            # In version 0.18.x the last line after compile is: Sketch uses xxx bytes (58%) of program storage space. Maximum is yyy bytes.
+            #In version 0.24.x +this is now on line 0.
+            #Need a more robust way to determine successful compile. Works for now.
+            self.update_state[device_name]['compile']=(str(cc[0]).find('Sketch uses')!=-1)
+            if not self.update_state[device_name]['compile']:
+                print('Firmware failed to compile %s at %s' % (sketch_name,src_path))
+                return False
+            else:
+                print('Success in firmware compile')
+
+
+            upload_command = 'arduino-cli upload  --config-file %s -p /dev/%s --fqbn hello-robot:samd:%s %s/arduino/%s' % (config_file, port_name, sketch_name, src_path,sketch_name)
+
+            user_msg_log(upload_command,user_display=verbose)
+            u = Popen(shlex.split(upload_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
+
+
+            if type(u) == bytes:
+                u=u.decode('utf-8')
+            uu = u.split('\n')
+            user_msg_log(u, user_display=False)
+            if verbose:
+                print(upload_command)
+                # Pretty print the result
+                for l in uu:
+                    k = l.split('\r')
+                    if len(k) == 1:
+                        print(k[0])
+                    else:
+                        for m in k:
+                            print(m)
+            success = uu[-1] == 'CPU reset.'
+
+            if not success:
+                print('Firmware flash. Failed to upload to %s' % (port_name))
+                return False
+            else:
+                print('Success in firmware flash.')
+                return True
+        else:
+            print('Firmware update %s. Failed to find device %s'%(tag,device_name))
+            return False
+
+    def save_update_state(self):
+        yaml.dump(self.update_state, '/tmp/firmware_updater_state.yaml', default_flow_style=False)
+    
+    def load_update_state(self):
+        #Return dict of update in process, None if none available
+        try:
+            with open('/tmp/firmware_updater_state.yaml', 'r') as s:
+                return yaml.load(s, Loader=yaml.FullLoader)
+        except IOError:
+            return None
 
     def __create_arduino_config_file(self):
         arduino_config = {'board_manager': {'additional_urls': []},
@@ -407,37 +373,6 @@ class FirmwareUpdater():
                           'telemetry': {'addr': ':9090', 'enabled': True}}
         with open(self.fw_available.repo_path + '/arduino-cli.yaml', 'w') as yaml_file:
             yaml.dump(arduino_config, yaml_file, default_flow_style=False)
-
-    def __check_ubuntu_version(self):
-        res = Popen(shlex.split('cat /etc/lsb-release | grep DISTRIB_RELEASE'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read().strip(b'\n')
-        return res == b'DISTRIB_RELEASE=18.04'
-
-    def __check_arduino_cli_install(self):
-        target_version = b'0.31.0'  # 0.18.3'
-        version = 'None'
-        res = Popen(shlex.split('arduino-cli version'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read()
-        do_install = False
-        if not (res[:11] == b'arduino-cli'):
-            do_install = True
-        else:
-            version = res[res.find(b'Version:') + 9:res.find(b' Commit')]
-            if version != target_version:
-                do_install = True
-        if do_install:
-            click.secho('WARNING:---------------------------------------------------------------------------------',
-                        fg="yellow", bold=True)
-            click.secho('WARNING: Compatible version of arduino_cli not installed. ', fg="yellow", bold=True)
-            click.secho('Requires version %s. Installed version of %s' % (target_version, version))
-            if click.confirm('Install now?'):
-                os.system(
-                    'curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh -s %s' % target_version.decode(
-                        'utf-8'))
-                os.system('arduino-cli config init')
-                os.system('arduino-cli core install arduino:samd@1.6.21')
-                return True
-            else:
-                return False
-        return True
 
     def pretty_print_target(self):
         click.secho(' UPDATING FIRMWARE TO... '.center(110, '#'), fg="cyan", bold=True)
@@ -470,146 +405,38 @@ class FirmwareUpdater():
                         bold=True)
         click.secho('------------------------------------------------', fg="yellow", bold=True)
 
-    def do_update(self, no_prompts=False, repo_path=None, verbose=False):
-        # Return True if system was upgraded
-        # Return False if system was not upgraded / error happened
-        self.num_update = 0
 
-        # Count how many updates doing
-        for device_name in self.target:
-            if self.fw_installed.is_device_valid(device_name) and self.target[device_name] is not None:
-                self.num_update = self.num_update + 1
-
-        self.pretty_print_target()
-
-        if not self.num_update:
-            click.secho('System is up to date. No updates to be done', fg="yellow", bold=True)
-            return False
-
-        self.print_upload_warning()
-        self.update_log = {}
-
-        if no_prompts or click.confirm('Proceed with update??'):
-            for device_name in self.target:
-                if self.target[device_name] is not None:
-                    self.update_log[device_name] = {'compile': False, 'flash': False, 'return_to_bus': False,'version_validate': False, 'calibration_flash': False}
-                    self.flash_firmware_update(device_name,self.target[device_name].to_string(),repo_path=repo_path, verbose=verbose)
-                    if not self.update_log[device_name]['compile'] or not self.update_log[device_name]['flash']:
-                        return False
-            click.secho('---- Firmware update of all devices complete! ----', fg="green", bold=True)
-
-
-            click.secho('Checking that Arduino devices returned to bus ')
-            print('---------------------------------')
-            no_return=[]
-            no_stepper_return=[]
-            all_success=True
-            for device_name in self.target:
-                print('Checking for %s. It may take several minutes to appear on the USB bus.'%device_name)
-                ts=time.time()
-                found=False
-                for i in range(30):
-                    if not self.wait_on_device(device_name, timeout=10.0):
-                        print('Trying again: %d\n'%i)
-                        # Bit of a hack.Sometimes after a firmware flash the device
-                        # Doesn't fully present on the USB bus with a serial No for Udev to find
-                        # In does present as an 'Arduino Zero' product. This will attempt to reset it
-                        # and re-present to the bus
-                        # time.sleep(1.0)
-                        # os.system('usbreset \"Arduino Zero\"')
-                        # time.sleep(1.0)
-                        print('')
-                    else:
-                        found=True
-                        break
-                if not found:
-                    click.secho('Device %s failed to return to bus after %f seconds.' %(device_name,time.time()-ts), fg="yellow", bold=True)
-                    no_return.append(device_name)
-                    all_success=False
-                    if device_name.find('motor') >= 0:
-                        no_stepper_return.append(device_name)
-                else:
-                    click.secho('Device %s returned to bus after %f seconds.'%(device_name,time.time()-ts), fg="green", bold=True)
-                    all_success = all_success and self.verify_firmware_version(device_name)
-                    print('')
-                    print('')
-
-            #NOTE: Move to exceptions and single device flow, can track where in the flow it fails.
-            self.post_firmware_update(device_name)
-
-            if len(no_return):
-                click.secho('Devices did not return to bus. Power cycle robot', fg="yellow",bold=True)
-                click.secho('Then run stretch_robot_system_check.py to confirm all devices present', fg="yellow", bold=True)
-                for device_name in no_stepper_return:
-                    click.secho('Device %s requires calibration data to be written after power cycle.'%device_name, fg="yellow", bold=True)
-                    click.secho('After power cycle run: REx_stepper_calibration_YAML_to_flash.py %s'%device_name, fg="yellow",bold=True)
+    def flash_stepper_calibration(self, device_name):
+        if device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-left-wheel':
+            click.secho(' Flashing Stepper Calibration: %s '.center(110, '#') % device_name, fg="cyan", bold=True)
+            if not self.wait_on_device(device_name):
+                click.secho('Device %s failed to return to bus. Power cycle may be required.' % device_name, fg="red", bold=True)
                 return False
-            if all_success:
+            #time.sleep(1.0)
+            motor = stretch_body.stepper.Stepper('/dev/' + device_name)
+            motor.startup()
+            if not motor.hw_valid:
+                click.secho('Failed to startup stepper %s' % device_name, fg="red", bold=True)
+                return False
+            else:
+                print('Writing gains to flash...')
+                motor.write_gains_to_flash()
+                motor.push_command()
+                print('Gains written to flash')
                 print('')
-                click.secho('----------------- Congratulations! ---------------.' ,fg="green", bold=True)
-                click.secho('No issues encountered. Firmware update successful.', fg="green", bold=True)
-            return all_success
+                print('Reading calibration data from YAML...')
+                data = motor.read_encoder_calibration_from_YAML()
+                print('Writing calibration data to flash...')
+                motor.write_encoder_calibration_to_flash(data)
+                print('Successful write of FLASH.')
+                self.wait_on_device(device_name)
+                motor.board_reset()
+                motor.push_command()
+                motor.transport.ser.close()
+                time.sleep(2.0)
+                self.wait_on_device(device_name)
+                print('Successful return of device to bus.')
         return True
-
-
-    def do_update_to(self, verbose=False, no_prompts=False):
-        # Return True if system was upgraded
-        # Return False if system was not upgraded / error happened
-        click.secho(' Select target firmware versions '.center(60, '#'), fg="cyan", bold=True)
-        for device_name in self.fw_recommended.recommended:
-            if self.use_device[device_name]:
-                vs = self.fw_available.versions[device_name]
-                if len(vs) and self.fw_recommended.recommended[device_name] is not None:
-                    print('')
-                    click.secho('---------- %s [%s]-----------' % (
-                    device_name.upper(), str(self.fw_installed.get_version(device_name))), fg="blue", bold=True)
-                    default_id = 0
-                    for i in range(len(vs)):
-                        if vs[i] == self.fw_recommended.recommended[device_name]:
-                            default_id = i
-                        print('%d: %s' % (i, vs[i]))
-                    print('----------------------')
-                    vt = None
-                    while vt == None:
-                        id = click.prompt('Please enter desired version id [Recommended]', default=default_id)
-                        if id >= 0 and id < len(vs):
-                            vt = vs[id]
-                        else:
-                            click.secho('Invalid ID', fg="red")
-                    print('Selected version %s for device %s' % (vt, device_name))
-                    self.target[device_name] = vt
-        print('')
-        print('')
-        return self.do_update(verbose=verbose, no_prompts=no_prompts)
-
-    def do_update_to_path(self, path_name, verbose=False, no_prompts=False):
-        # Burn the Head of the branch to each board regardless of what is currently installed
-        click.secho('>>> Flashing firmware from path %s ' % path_name, fg="cyan", bold=True)
-        # Check that version of target path is compatible
-        for device_name in self.target:
-            if self.use_device[device_name]:
-                sketch_name = self.get_sketch_name(device_name)
-                target_version = self.get_firmware_version_from_path(sketch_name, path_name)
-                if target_version is None:
-                    return False
-                self.target[device_name] = target_version
-                path_protocol = 'p' + str(target_version.protocol)
-                if not self.fw_installed.is_protocol_supported(device_name, path_protocol):
-                    click.secho('---------------------------', fg="yellow")
-                    click.secho(
-                        'Target firmware path of %s is incompatible with installed Stretch Body for device %s' % (
-                        path_name, device_name), fg="yellow")
-                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(
-                        *self.fw_installed.get_supported_protocols(device_name))
-                    click.secho('Installed Stretch Body supports protocols %s' % x, fg="yellow")
-                    click.secho('Target path supports protocol %s' % path_protocol, fg="yellow")
-                    if path_protocol > self.fw_installed.max_protocol_supported(device_name):
-                        click.secho('Upgrade Stretch Body first...', fg="yellow")
-                    else:
-                        click.secho('Downgrade Stretch Body first...', fg="yellow")
-                    return False
-        repo_path = path_name[:path_name.rfind('arduino')]
-        return self.do_update(repo_path=repo_path, verbose=verbose, no_prompts=no_prompts)
 
     def do_update_to_branch(self, verbose=False, no_prompts=False):
         # Return True if system was upgraded
@@ -653,41 +480,8 @@ class FirmwareUpdater():
                     return False
         return self.do_update(verbose=verbose, no_prompts=no_prompts)
 
-    def flash_stepper_calibration(self, device_name):
-        if device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-left-wheel':
-            click.secho(' Flashing Stepper Calibration: %s '.center(110, '#') % device_name, fg="cyan", bold=True)
-            if not self.wait_on_device(device_name):
-                click.secho('Device %s failed to return to bus. Power cycle may be required.' % device_name, fg="red", bold=True)
-                return False
-            #time.sleep(1.0)
-            motor = stretch_body.stepper.Stepper('/dev/' + device_name)
-            motor.startup()
-            if not motor.hw_valid:
-                click.secho('Failed to startup stepper %s' % device_name, fg="red", bold=True)
-                return False
-            else:
-                print('Writing gains to flash...')
-                motor.write_gains_to_flash()
-                motor.push_command()
-                print('Gains written to flash')
-                print('')
-                print('Reading calibration data from YAML...')
-                data = motor.read_encoder_calibration_from_YAML()
-                print('Writing calibration data to flash...')
-                motor.write_encoder_calibration_to_flash(data)
-                print('Successful write of FLASH.')
-                self.wait_on_device(device_name)
-                motor.board_reset()
-                motor.push_command()
-                motor.transport.ser.close()
-                time.sleep(2.0)
-                self.wait_on_device(device_name)
-                print('Successful return of device to bus.')
-        return True
-
-
     def verify_firmware_version(self,device_name):
-        fw_installed = InstalledFirmware({device_name: True})  # Pull the currently installed system from fw
+        fw_installed = FirmwareInstalled({device_name: True})  # Pull the currently installed system from fw
         if not fw_installed.is_device_valid(device_name):  # Device may not have come back on bus
             print('%s | No device available' % device_name.upper().ljust(25))
             print('')
@@ -701,25 +495,6 @@ class FirmwareUpdater():
             else:
                 click.secho('%s | %s ' % (device_name.upper().ljust(25), 'Firmware update failure!!'.ljust(40)),fg="red", bold=True)
                 return False
-
-    def post_firmware_update(self, device_name):
-        #Assumes device is back on bus after an firmware flash
-        #Return True if no errors
-        m=' Performing Post Firmware Update for %s '%device_name
-        click.secho(m.center(110, '#'), fg="cyan", bold=True)
-
-        #Update stepper calibration on steppers
-        if self.fw_updated[device_name] and device_name.find('motor')>=0:
-            time.sleep(2.0)  # Give time to get back on bus
-            if not self.flash_stepper_calibration(device_name):
-                click.secho('%s | %s ' % (device_name.upper().ljust(25), 'Stepper calibration flash failure!!'.ljust(40)),fg="red", bold=True)
-                click.secho('To manually restore stepper calibration, after power-cycling robot run ', fg="red", bold=True)
-                click.secho('REx_stepper_calibration_YAML_to_flash.py %s' % device_name)
-                return False
-
-
-
-        return False
 
     def get_firmware_version_from_path(self,sketch_name,path):
         file_path = path+'/'+sketch_name+'/Common.h'
@@ -749,161 +524,3 @@ class FirmwareUpdater():
                 return FirmwareVersion(version)
         return None
 
-    def get_sketch_name(self,device_name):
-        if device_name=='hello-motor-left-wheel' or device_name=='hello-motor-right-wheel' or device_name=='hello-motor-arm' or device_name=='hello-motor-lift':
-            return 'hello_stepper'
-        if device_name == 'hello-wacc':
-            return 'hello_wacc'
-        if device_name == 'hello-pimu':
-            return 'hello_pimu'
-
-    def exec_process(self,cmdline, silent, input=None, **kwargs):
-        """Execute a subprocess and returns the returncode, stdout buffer and stderr buffer.
-           Optionally prints stdout and stderr while running."""
-        try:
-            sub = Popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                                   **kwargs)
-            stdout, stderr = sub.communicate(input=input)
-            returncode = sub.returncode
-            if not silent:
-                sys.stdout.write(stdout.decode('utf-8'))
-                sys.stderr.write(stderr.decode('utf-8'))
-        except OSError as e:
-            if e.errno == 2:
-                raise RuntimeError('"%s" is not present on this system' % cmdline[0])
-            else:
-                raise
-        if returncode != 0:
-            raise RuntimeError('Got return value %d while executing "%s", stderr output was:\n%s' % (
-            returncode, " ".join(cmdline), stderr.rstrip(b"\n")))
-        return stdout
-
-    # ###################################
-    def is_device_present(self,device_name):
-        try:
-            self.exec_process(['ls', '/dev/'+device_name], True)
-            return True
-        except RuntimeError as e:
-            return False
-
-    def wait_on_device(self,device_name,timeout=10.0):
-        #Wait for device to appear on bus for timeout seconds
-        print('Waiting for device %s to return to bus.'%device_name)
-        ts=time.time()
-        itr=0
-        while(time.time()-ts<timeout):
-            if self.is_device_present(device_name):
-                return True
-            itr=itr+1
-            if itr % 5 == 0:
-                sys.stdout.write('.')
-                sys.stdout.flush()
-            time.sleep(0.1)
-        return False
-
-    def get_port_name(self, device_name):
-        try:
-            port_name = Popen(shlex.split("ls -l /dev/" + device_name), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read().strip().split()[-1]
-            if not type(port_name)==str:
-                port_name=port_name.decode('utf-8')
-            return port_name
-        except IndexError:
-            return None
-
-    def does_stepper_have_encoder_calibration_YAML(self,device_name):
-        d=stretch_body.device.Device(req_params=False)
-        sn = d.robot_params[device_name]['serial_no']
-        fn = 'calibration_steppers/' + device_name + '_' + sn + '.yaml'
-        enc_data = stretch_body.hello_utils.read_fleet_yaml(fn)
-        return len(enc_data)!=0
-
-    def flash_firmware_update(self,device_name, tag,repo_path=None,verbose=False):
-        click.secho('-------- FIRMWARE FLASH %s | %s ------------'%(device_name,tag), fg="cyan", bold=True)
-        config_file = self.fw_available.repo_path + '/arduino-cli.yaml'
-
-        user_msg_log('Config: '+str(config_file), user_display=verbose)
-        user_msg_log('Repo: '+str(repo_path), user_display=verbose)
-
-        sketch_name=None
-        if device_name == 'hello-motor-left-wheel' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift':
-            sketch_name = 'hello_stepper'
-        if device_name == 'hello-wacc':
-            sketch_name = 'hello_wacc'
-        if device_name == 'hello-pimu':
-            sketch_name = 'hello_pimu'
-
-        if sketch_name=='hello_stepper' and not self.does_stepper_have_encoder_calibration_YAML(device_name):
-            print('Encoder data has not been stored for %s and may be lost. Aborting firmware flash.'%device_name)
-            return False
-
-        print('Looking for device %s on bus' % device_name)
-        if not self.wait_on_device(device_name, timeout=5.0):
-            print('Failure: Device not on bus.')
-            return False
-        port_name = self.get_port_name(device_name)
-        user_msg_log('Device: %s Port: %s'%(device_name,port_name), user_display=verbose)
-
-        if port_name is not None and sketch_name is not None:
-
-            print('Starting programming. This will take about 5s...')
-            if repo_path is None:
-                os.chdir(self.fw_available.repo_path)
-                os.system('git checkout '+tag+'>/dev/null 2>&1')
-                src_path=self.fw_available.repo_path
-            else:
-                src_path=repo_path
-
-            compile_command = 'arduino-cli compile --config-file %s --fqbn hello-robot:samd:%s %s/arduino/%s'%(config_file,sketch_name,src_path,sketch_name)
-            user_msg_log(compile_command,user_display=verbose)
-            c=Popen(shlex.split(compile_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
-            if type(c)==bytes:
-                c=c.decode("utf-8")
-            cc = c.split('\n')
-            user_msg_log(c, user_display=verbose)
-
-            # In version 0.18.x the last line after compile is: Sketch uses xxx bytes (58%) of program storage space. Maximum is yyy bytes.
-            #In version 0.24.x +this is now on line 0.
-            #Need a more robust way to determine successful compile. Works for now.
-            self.update_log[device_name]['compile']=(str(cc[0]).find('Sketch uses')!=-1)
-            if not self.update_log[device_name]['compile']:
-                print('Firmware failed to compile %s at %s' % (sketch_name,src_path))
-                return False
-            else:
-                print('Success in firmware compile')
-
-
-            upload_command = 'arduino-cli upload  --config-file %s -p /dev/%s --fqbn hello-robot:samd:%s %s/arduino/%s' % (config_file, port_name, sketch_name, src_path,sketch_name)
-
-            user_msg_log(upload_command,user_display=verbose)
-            u = Popen(shlex.split(upload_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
-
-
-            if type(u) == bytes:
-                u=u.decode('utf-8')
-            uu = u.split('\n')
-            user_msg_log(u, user_display=False)
-            if verbose:
-                print(upload_command)
-                # Pretty print the result
-                for l in uu:
-                    k = l.split('\r')
-                    if len(k) == 1:
-                        print(k[0])
-                    else:
-                        for m in k:
-                            print(m)
-            success = uu[-1] == 'CPU reset.'
-
-            print('')
-            print('PIMU', self.get_port_name('hello-pimu'))
-            print('WACC', self.get_port_name('hello-wacc'))
-
-            if not success:
-                print('Firmware flash. Failed to upload to %s' % (port_name))
-                return False
-            else:
-                print('Success in firmware flash.')
-                return True
-        else:
-            print('Firmware update %s. Failed to find device %s'%(tag,device_name))
-            return False

--- a/python/stretch_factory/firmware_updater.py
+++ b/python/stretch_factory/firmware_updater.py
@@ -18,65 +18,509 @@ from stretch_factory.firmware_available import FirmwareAvailable
 from stretch_factory.firmware_recommended import FirmwareRecommended
 from stretch_factory.firmware_installed import FirmwareInstalled
 from stretch_factory.firmware_version import FirmwareVersion
-from stretch_factory.firmware_utils import *
+import stretch_factory.firmware_utils as fwu
+
+import stretch_factory.hello_device_utils as hdu
+
+# def get_zombie_port():
+#     devices = {'hello-motor-arm': None, 'hello-motor-right-wheel': None, 'hello-motor-left-wheel': None,
+#                'hello-pimu': None, 'hello-wacc': None, 'hello-motor-lift': None}
+#     missing=[]
+#     att = hdu.get_all_ttyACMx()
+#     for d in devices:
+#         x=hdu.get_device_ttyACMx(d)
+#         if x is not None:
+#             devices[d]='/dev/'+x
+#         else:
+#             missing.append(d)
+#
+#     if len(missing)==0:
+#         print('No zombie devices found')
+#     else:
+#         print('Potential zombie devices: ',missing)
+
+    # if len(att)!=len(devices):
+    #     print('Can only restore a zombie port when all ')
+    #
+    # return port, target    # if len(att)!=len(devices):
+    #     print('Can only restore a zombie port when all ')
+    #
+    # return port, target
 
 class FirmwareUpdater():
-    def __init__(self, use_device):
-        self.use_device = use_device
-        self.fw_installed = FirmwareInstalled(use_device)
-        for device_name in self.use_device.keys():
-            self.use_device[device_name] = self.use_device[device_name] and self.fw_installed.is_device_valid(device_name)
-        self.fw_available = FirmwareAvailable(use_device)
-        self.fw_recommended = FirmwareRecommended(use_device, self.fw_installed, self.fw_available)
-        self.target = self.fw_recommended.recommended.copy()
+    def __init__(self, use_device,args):
+        #use_device = {'hello-motor-arm': True, 'hello-motor-right-wheel': True, 'hello-motor-left-wheel': True, 'hello-pimu': True, 'hello-wacc': True,'hello-motor-lift': True}
+        self.ready_to_run = False
+        self.resume_tmp_filename='/tmp/REx_firmware_updater_resume.yaml'
+        self.args=args
+        state_from_yaml = self.from_yaml()
+
+        if args.zombie:
+            self.ready_to_run=True
+            return
 
 
-    def startup(self):
-        # if not self.__check_ubuntu_version():
-        #    print('Firmware Updater does not work on Ubuntu 20.04 currently. Please try again in Ubuntu 18.04')
-        #   return False
-        if self.__check_arduino_cli_install():
-            self.__create_arduino_config_file()
+        if args.resume:
+            if not state_from_yaml:
+                click.secho('WARNING: A previous firmware update is not available. Unable to resume', fg="yellow",bold=True)
+                self.ready_to_run = False
+                return
+            else:
+
+                self.state = state_from_yaml  # Use the disk version
+                devs=' '
+                for d in self.state['use_device']:
+                    if self.state['use_device'][d]:
+                        devs=devs+' '+str(d)+' |'
+                devs=devs[:-1]
+                click.secho('\nResuming firmware updates for:%s '%devs, fg="green",bold=True)
+                print('')
+                self.ready_to_run = True
+        else:
+            if state_from_yaml:
+                click.secho('WARNING: A previous firmware update is incomplete', fg="yellow", bold=True)
+                click.secho('WARNING: Run REx_firmware_udpater.py --resume', fg="yellow", bold=True)
+                click.secho('WARNING: Or delete file %s and try again.'%self.resume_tmp_filename, fg="yellow",bold=True)
+                self.ready_to_run = False
+                return
+    
+            self.state = {}
+            self.state['use_device']=use_device
+            self.state['verbose'] = args.verbose
+            self.state['no_prompts'] = args.no_prompts
+            self.state['install_version'] = args.install_version
+            self.state['install_path'] = args.install_path
+            self.state['install_branch'] = args.install_branch
+            if self.state['install_path'] and self.state['install_path'][0] != '/':
+                    self.state['install_path'] = os.getcwd() + '/' + self.state['install_path']
+            self.state['completed']={}
+            for d in use_device:
+                if use_device[d]:
+                    self.state['completed'][d] = {'flash': False,
+                                                            'return_to_bus': False,
+                                                            'version_validate': False,
+                                                            'calibration_flash': False,
+                                                            'return_to_bus2': False}
+
+
+        #Update the devices to flash based on the available devices on bus
+        self.fw_installed = FirmwareInstalled(self.state['use_device'])
+        for d in self.state['use_device']:
+            self.state['use_device'][d] = self.state['use_device'][d] and self.fw_installed.is_device_valid(d)
+
+        self.fw_available = FirmwareAvailable(self.state['use_device'])
+        self.fw_recommended = FirmwareRecommended(self.state['use_device'], self.fw_installed, self.fw_available)
+
+        self.create_arduino_config_file()
+        self.ready_to_run = fwu.check_arduino_cli_install()
+
+        # Set the target version to flash to recommended for each device
+        #This dict has a FirmwareVersion target for each device that has a valid (and desired) update
+        self.target = {}
+
+        if args.resume:
+            for d in self.state['use_device']:
+                if self.state['use_device'][d]:
+                    self.target[d] = FirmwareVersion(self.state['target_str'][d])
+        else:
+            self.state['repo_path']=None
+
+            #Default target is recommended
+            for d in self.state['use_device']:
+                if self.state['use_device'][d]:
+                    if d in self.fw_recommended.recommended:
+                        self.target[d] = self.fw_recommended.recommended[d]
+
+            #Now overwrite default target if given command line options
+            if args.install_version:
+                self.ready_to_run = self.ready_to_run and self.set_target_from_install_version()
+
+            if self.state['install_path']:
+                self.ready_to_run = self.ready_to_run and self.set_target_from_install_path(self.state['install_path'])
+
+            if args.install_branch:
+                self.ready_to_run = self.ready_to_run and self.set_target_from_install_branch()
+
+            # Store updated target for potential future resume
+            self.state['target_str'] = {}
+            for d in self.target:
+                    self.state['target_str'][d] = self.target[d].to_string()
+
+        # Count how many updates doing
+        num_update = 0
+        for device_name in self.target:
+            if self.fw_installed.is_device_valid(device_name):
+                num_update = num_update + 1
+        self.pretty_print_target()
+        if not num_update:
+            if not args.resume:
+                click.secho('No updates to be done', fg="yellow", bold=True)
+            else:
+                click.secho('WARNING: Unable to resume update. Not all devices returned to bus successfully', fg="yellow", bold=True)
+                click.secho('WARNING: Power cycle robot.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py --resume')
+            self.ready_to_run=False
+        #At this point self.state dictionary has all information needed to run an update cycle
+
+    def to_yaml(self):
+        with open(self.resume_tmp_filename, 'w') as yaml_file:
+         yaml.dump(self.state, yaml_file, default_flow_style=False)
+
+    def from_yaml(self):
+        try:
+            with open(self.resume_tmp_filename, 'r') as s:
+                return  yaml.load(s, Loader=yaml.FullLoader)
+        except IOError:
+            return None
+
+    def delete_yaml(self):
+        if os.path.exists(self.resume_tmp_filename):
+            os.system('rm %s'%self.resume_tmp_filename)
+
+# ########################################################################################################3
+
+    def get_port_from_user(self):
+        mapping = hdu.get_hello_ttyACMx_mapping()
+        click.secho('-------- Available Ports ------------', fg="cyan",bold=True)
+        m=[]
+        for a in mapping['ACMx']:
+            if mapping['ACMx'][a] is None:
+                print('%d | %s' % (len(m), a))
+                m.append(a)
+        dp = None
+        while dp == None:
+            id = click.prompt('Please enter desired port id', default=0)
+            if id >= 0 and id < len(mapping['ACMx']):
+                dp = m[id]
+            else:
+                click.secho('Invalid ID', fg="red")
+        return dp
+
+    def get_device_from_user(self):
+        click.secho('--------Available Devices ------------' , fg="cyan",bold=True)
+        m=['hello-motor-arm','hello-motor-left-wheel' ,'hello-motor-right-wheel' ,'hello-motor-lift','hello-wacc','hello-pimu']
+        for i in range(len(m)):
+            print('%d | %s ' % (i, m[i]))
+        dp = None
+        while dp == None:
+            id = click.prompt('Please enter desired device id', default=0)
+            if id >= 0 and id < len(m):
+                dp = m[id]
+            else:
+                click.secho('Invalid ID', fg="red")
+        return dp
+
+    def recover_zombie(self):
+        print('')
+        print('Will attempt to recover a zombie device by flashing Stretch Firmware master code')
+        print('')
+        device_name = self.get_device_from_user()
+        print('')
+        port_name=self.get_port_from_user()
+        print('')
+        print('Selected port %s for device %s' % (port_name, device_name))
+        print('')
+        if  click.confirm('Proceed with firmware flash?'):
+            self.fw_available = FirmwareAvailable({device_name:True})
+            protocols=fwu.get_device_protocols(device_name)
+            target=self.fw_available.get_most_recent_version(device_name,protocols).to_string()
+            return self.do_device_flash(device_name,tag=target, repo_path=None, verbose=self.args.verbose, port_name=port_name)
+        return False
+
+    def run(self):
+        if not self.ready_to_run:
+            click.secho('WARNING: Unable to configure system for firmware update', fg="yellow", bold=True)
+            return False
+
+        if self.args.zombie:
+            return self.recover_zombie()
+
+
+        self.print_upload_warning()
+
+        #self.pretty_print_state()
+        #Advance the state machine
+        if self.state['no_prompts'] or click.confirm('Proceed with update??'):
+            #Flash all devices
+            for d in self.target:
+                if not self.state['completed'][d]['flash']:
+                    self.state['completed'][d]['flash']=self.do_device_flash(d,self.target[d].to_string(),self.state['repo_path'],self.state['verbose'])
+
+            if not self.all_completed('flash'):
+                click.secho('WARNING: Not all devices flashed firmware successfully', fg="yellow", bold=True)
+                click.secho('WARNING: Power cycle robot.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py --resume')
+                self.to_yaml()
+                return False
+
+            click.secho(' CHECK #1 IF DEVICES RETURNED TO BUS... '.center(110, '#'), fg="cyan", bold=True)
+            for d in self.target:
+                if  not self.state['completed'][d]['return_to_bus']:
+                    self.state['completed'][d]['return_to_bus']=self.wait_on_return_to_bus(d)
+
+            if not self.all_completed('return_to_bus'):
+                click.secho('WARNING: Not all devices returned to bus successfully', fg="yellow", bold=True)
+                click.secho('WARNING: Power cycle robot.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py --resume')
+                self.to_yaml()
+                return False
+
+            click.secho(' CHECKING FOR CORRECT VERSION UPDATES... '.center(110, '#'), fg="cyan", bold=True)
+            for d in self.target:
+                if not self.state['completed'][d]['version_validate']:
+                    self.state['completed'][d]['version_validate'] = self.verify_firmware_version(d)
+                    if not self.state['completed'][d]['version_validate']: #If failed, force to try upload again
+                        self.state['completed'][d]['flash']=False
+                        self.state['completed'][d]['return_to_bus']=False
+
+            if not self.all_completed('version_validate'):
+                click.secho('WARNING: Not all devices have updated to target firmware version', fg="yellow", bold=True)
+                click.secho('WARNING: Power cycle robot.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py --resume')
+                self.to_yaml()
+                return False
+
+            click.secho(' RESTORING CALIBRATION DATA... '.center(110, '#'), fg="cyan", bold=True)
+            for d in self.target:
+                if not self.state['completed'][d]['calibration_flash']:
+                    self.state['completed'][d]['calibration_flash'] = self.flash_stepper_calibration(d)
+
+            if not self.all_completed('calibration_flash'):
+                click.secho('WARNING: Not all devices have encoder calibration flashed', fg="yellow", bold=True)
+                click.secho('WARNING: Power cycle robot.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py --resume')
+                self.to_yaml()
+                return False
+
+            click.secho(' CHECK #2 IF DEVICES RETURNED TO BUS... '.center(110, '#'), fg="cyan", bold=True)
+            for d in self.target:
+                if  not self.state['completed'][d]['return_to_bus2']:
+                    self.state['completed'][d]['return_to_bus2']=self.wait_on_return_to_bus(d)
+
+            if not self.all_completed('return_to_bus2'):
+                click.secho('WARNING: Not all devices returned to bus successfully', fg="yellow", bold=True)
+                click.secho('WARNING: Power cycle robot.', fg="yellow", bold=True)
+                click.secho('WARNING: Then run: REx_firmware_udpater.py - -resume')
+                self.to_yaml()
+                return False
+
+            print('')
+            click.secho(' CONGRATULATIONS... '.center(110, '#'), fg="cyan", bold=True)
+            click.secho('No issues encountered. Firmware update successful.', fg="green", bold=True)
+            self.delete_yaml()
             return True
+    # ########################################################################################################3
+
+
+
+
+    def all_completed(self,state_name):
+        all_completed=True
+        for d in self.target:
+            all_completed=all_completed and self.state['completed'][d][state_name]
+        return all_completed
+
+# ########################################################################################################################
+    def do_device_flash(self, device_name, tag, repo_path=None, verbose=False, port_name=None):
+        click.secho('-------- FIRMWARE FLASH %s | %s ------------' % (device_name, tag), fg="cyan", bold=True)
+        config_file = self.fw_available.repo_path + '/arduino-cli.yaml'
+
+        fwu.user_msg_log('Config: ' + str(config_file), user_display=verbose)
+        fwu.user_msg_log('Repo: ' + str(repo_path), user_display=verbose)
+
+        sketch_name=fwu.get_sketch_name(device_name)
+
+        if sketch_name == 'hello_stepper' and not fwu.does_stepper_have_encoder_calibration_YAML(device_name):
+            print('Encoder data has not been stored for %s and may be lost. Aborting firmware flash.' % device_name)
+            return False
+
+        if port_name is None:
+            print('Looking for device %s on bus' % device_name)
+            if not fwu.wait_on_device(device_name, timeout=5.0):
+                print('Failure: Device not on bus.')
+                return False
+            port_name = fwu.get_port_name(device_name)
+
+        fwu.user_msg_log('Device: %s Port: %s' % (device_name, port_name), user_display=verbose)
+
+        if port_name is not None and sketch_name is not None:
+            print('Starting programming. This will take about 5s...')
+            if repo_path is None:
+                os.chdir(self.fw_available.repo_path)
+                cmd='git checkout ' + tag + '>/dev/null 2>&1'
+                os.system(cmd)
+                if verbose:
+                    print('Ran: %s from %s'%(cmd,self.fw_available.repo_path))
+                src_path = self.fw_available.repo_path
+            else:
+                src_path = repo_path
+
+            compile_command = 'arduino-cli compile --config-file %s --fqbn hello-robot:samd:%s %s/arduino/%s' % (
+            config_file, sketch_name, src_path, sketch_name)
+            fwu.user_msg_log(compile_command, user_display=verbose)
+            c = Popen(shlex.split(compile_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,
+                      close_fds=True).stdout.read().strip()
+            if type(c) == bytes:
+                c = c.decode("utf-8")
+            cc = c.split('\n')
+            fwu.user_msg_log(c, user_display=verbose)
+
+            # In version 0.18.x the last line after compile is: Sketch uses xxx bytes (58%) of program storage space. Maximum is yyy bytes.
+            # In version 0.24.x +this is now on line 0.
+            # Need a more robust way to determine successful compile. Works for now.
+            success = (str(cc[0]).find('Sketch uses') != -1)
+            if not success:
+                print('Firmware failed to compile %s at %s' % (sketch_name, src_path))
+                return False
+            else:
+                print('Success in firmware compile')
+
+            upload_command = 'arduino-cli upload  --config-file %s -p /dev/%s --fqbn hello-robot:samd:%s %s/arduino/%s' % (
+            config_file, port_name, sketch_name, src_path, sketch_name)
+
+            fwu.user_msg_log(upload_command, user_display=verbose)
+            u = Popen(shlex.split(upload_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,
+                      close_fds=True).stdout.read().strip()
+
+            if type(u) == bytes:
+                u = u.decode('utf-8')
+            uu = u.split('\n')
+            fwu.user_msg_log(u, user_display=False)
+            if verbose:
+                print(upload_command)
+                # Pretty print the result
+                for l in uu:
+                    k = l.split('\r')
+                    if len(k) == 1:
+                        print(k[0])
+                    else:
+                        for m in k:
+                            print(m)
+            success = uu[-1] == 'CPU reset.'
+
+            if not success:
+                print('Firmware flash. Failed to upload to %s' % (port_name))
+                return False
+            else:
+                print('Success in firmware flash.')
+                return True
+        else:
+            print('Firmware update %s. Failed to find device %s' % (tag, device_name))
+            return False
+
+# ########################################################################################################3
+    def wait_on_return_to_bus(self,device_name):
+        click.secho('Checking that device %s returned to bus '%device_name)
+        print('It may take several minutes to appear on the USB bus.' )
+        ts = time.time()
+        found = False
+        for i in range(30):
+            if not fwu.wait_on_device(device_name, timeout=10.0):
+                print('Trying again: %d\n' % i)
+                # Bit of a hack.Sometimes after a firmware flash the device
+                # Doesn't fully present on the USB bus with a serial No for Udev to find
+                # In does present as an 'Arduino Zero' product. This will attempt to reset it
+                # and re-present to the bus
+                # time.sleep(1.0)
+                # os.system('usbreset \"Arduino Zero\"')
+                # time.sleep(1.0)
+                print('')
+            else:
+                found = True
+                break
+        if not found:
+            click.secho('Device %s failed to return to bus after %f seconds.' % (device_name, time.time() - ts),fg="yellow", bold=True)
+            return False
+        else:
+            click.secho('Device %s returned to bus after %f seconds.' % (device_name, time.time() - ts),fg="green", bold=True)
+        return True
+# ########################################################################################################3
+    def verify_firmware_version(self,device_name):
+        fw_installed = FirmwareInstalled({device_name: True})  # Pull the currently installed system from fw
+        if not fw_installed.is_device_valid(device_name):  # Device may not have come back on bus
+            print('%s | No device available' % device_name.upper().ljust(25))
+            print('')
+            return False
+        else:
+            click.secho(' Confirming Firmware Updates '.center(110, '#'), fg="cyan", bold=True)
+            v_curr = fw_installed.get_version(device_name)  # Version that is now on the board
+            if v_curr == self.target[device_name]:
+                click.secho('PASS: %s | Installed %s | Target %s ' % (device_name.upper().ljust(25), v_curr.to_string().ljust(40),self.target[device_name].to_string().ljust(40)), fg="green")
+                return True
+            else:
+                click.secho('FAIL: %s | Installed %s | Target %s ' % (device_name.upper().ljust(25), v_curr.to_string().ljust(40), self.target[device_name].to_string().ljust(40)),fg="red")
         return False
 
 # ########################################################################################################3
-    def get_update_to(self):
-        #Override self.target with user input
+    def flash_stepper_calibration(self, device_name):
+        if device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-left-wheel':
+            click.secho(' Flashing Stepper Calibration: %s '.center(110, '#') % device_name, fg="cyan", bold=True)
+            if not fwu.wait_on_device(device_name):
+                click.secho('Device %s failed to return to bus.' % device_name, fg="red", bold=True)
+                return False
+            #time.sleep(1.0)
+            motor = stretch_body.stepper.Stepper('/dev/' + device_name)
+            motor.startup()
+            if not motor.hw_valid:
+                click.secho('Failed to startup stepper %s' % device_name, fg="red", bold=True)
+                return False
+            else:
+                print('Writing gains to flash...')
+                motor.write_gains_to_flash()
+                motor.push_command()
+                print('Gains written to flash')
+                print('')
+                print('Reading calibration data from YAML...')
+                data = motor.read_encoder_calibration_from_YAML()
+                print('Writing calibration data to flash...')
+                motor.write_encoder_calibration_to_flash(data)
+                print('Successful write of FLASH.')
+                fwu.wait_on_device(device_name)
+                motor.board_reset()
+                motor.push_command()
+                motor.transport.ser.close()
+                time.sleep(2.0) #Give time to return to bus
+                return True
+        return True
+# ########################################################################################################3
+
+    def set_target_from_install_version(self):
+        # Return True if system was upgraded
+        # Return False if systvt = None
+        #                     while vt == None:
+        #                         id = click.prompt('Please enter desired version id [Recommended]', default=default_id)
+        #                         if id >= 0 and id < len(vs):
+        #                             vt = vs[id]
+        #                         else:
+        #                             click.secho('Invalid ID', fg="red")
+        #                     print('Selected version %s for device %s' % (vt, device_name))em was not upgraded / error happened
         click.secho(' Select target firmware versions '.center(60, '#'), fg="cyan", bold=True)
-        for device_name in self.fw_recommended.recommended:
-            if self.use_device[device_name]:
+        for device_name in self.fw_recommended.recommended.keys():
+            if self.state['use_device'][device_name]:
                 vs = self.fw_available.versions[device_name]
                 if len(vs) and self.fw_recommended.recommended[device_name] is not None:
                     print('')
                     click.secho('---------- %s [%s]-----------' % (
-                        device_name.upper(), str(self.fw_installed.get_version(device_name))), fg="blue",
-                                bold=True)
+                    device_name.upper(), str(self.fw_installed.get_version(device_name))), fg="blue", bold=True)
                     default_id = 0
                     for i in range(len(vs)):
                         if vs[i] == self.fw_recommended.recommended[device_name]:
                             default_id = i
                         print('%d: %s' % (i, vs[i]))
                     print('----------------------')
-                    vt = None
-                    while vt == None:
-                        id = click.prompt('Please enter desired version id [Recommended]', default=default_id)
-                        if id >= 0 and id < len(vs):
-                            vt = vs[id]
-                        else:
-                            click.secho('Invalid ID', fg="red")
-                    print('Selected version %s for device %s' % (vt, device_name))
+
                     self.target[device_name] = vt
         print('')
         print('')
+        return True
 
-    def get_update_to_path(self, path_name):
+    def set_target_from_install_path(self, path_name):
         # Burn the Head of the branch to each board regardless of what is currently installed
         click.secho('>>> Flashing firmware from path %s ' % path_name, fg="cyan", bold=True)
         # Check that version of target path is compatible
         for device_name in self.target:
-            if self.use_device[device_name]:
-                sketch_name = self.get_sketch_name(device_name)
+            if self.state['use_device'][device_name]:
+                sketch_name = fwu.get_sketch_name(device_name)
                 target_version = self.get_firmware_version_from_path(sketch_name, path_name)
                 if target_version is None:
                     return False
@@ -96,148 +540,55 @@ class FirmwareUpdater():
                     else:
                         click.secho('Downgrade Stretch Body first...', fg="yellow")
                     return False
-        self.repo_path = path_name[:path_name.rfind('arduino')]
+        self.state['repo_path']=path_name[:path_name.rfind('arduino')]
         return True
 
-    # ########################################################################################################3
-    def run(self,args):
-        #First construct the updater state dictionary
-        self.update_state = self.load_update_state()
-        if args.do_resume and not self.update_state:
-            click.secho('WARNING: A previous firmware update is not available. Unable to resume', fg="yellow",bold=True)
-            return False
-
-        if self.update_state and not args.do_resume:
-            click.secho('WARNING: A previous firmware update is incomplete', fg="yellow", bold=True)
-            click.secho('WARNING: Run REx_firmware_udpater.py --resume', fg="yellow", bold=True)
-            click.secho('WARNING: Or delete file /tmp/firmware_updater_state.yaml and try again.', fg="yellow",bold=True)
-            return False
-
-        if not self.update_state: #Starting on a new update
-            self.update_state = {}
-            self.update_state['verbose'] = args.verbose
-            self.update_state['no_prompts'] = args.no_prompts
-            self.update_state['verbose'] = args.verbose
-            self.update_state['install_version'] = args.install_version
-
-            if args.install_path:
-                if args.install_path[0] != '/':
-                    self.update_state['install_path']=os.getcwd() + '/' + args.install_path
-                else:
-                    self.update_state['install_path']=args.install_path
-            for device_name in self.target:
-                if self.target[device_name] is not None:
-                    self.update_state[device_name] = {'flash': False,
-                                                      'return_to_bus': False,
-                                                      'version_validate':False,
-                                                      'calibration_flash': False}
-
-
-            # if args.install_version:
-            #     self.get_update_to()
-            #
-            # if args.install_path:
-            #     self.get_update_to_path(self.update_state['install_path'])
-
-            self.update_state['target'] = self.target.copy()
-
-
-            # Count how many updates doing
-            self.num_update = 0
-            for device_name in self.target:
-                if self.fw_installed.is_device_valid(device_name) and self.target[device_name] is not None:
-                    self.num_update = self.num_update + 1
-            self.pretty_print_target()
-            if not self.num_update:
-                click.secho('System is up to date. No updates to be done', fg="yellow", bold=True)
+    def set_target_from_install_branch(self,):
+        # Return True if system was upgraded
+        # Return False if system was not upgraded / error happened
+        click.secho(' Select target branch '.center(60, '#'), fg="cyan", bold=True)
+        branches = self.fw_available.get_remote_branches()
+        for id in range(len(branches)):
+            print('%d: %s' % (id, branches[id]))
+        print('')
+        branch_name = None
+        while branch_name == None:
+            try:
+                id = click.prompt('Please enter desired branch id', default=0)
+            except click.exceptions.Abort:
                 return False
-            self.print_upload_warning()
+            if id >= 0 and id < len(branches):
+                branch_name = branches[id]
+            else:
+                click.secho('Invalid ID', fg="red")
+        print('Selected branch %s' % branch_name)
+        self.state['install_branch']=branch_name
+        # Check that version of target branch is compatible
+        for device_name in self.target:
+            if self.state['use_device'][device_name]:
+                sketch_name = fwu.get_sketch_name(device_name)
+                target_version = self.get_firmware_version_from_git(sketch_name, branch_name)
+                self.target[device_name] = target_version
+                git_protocol = 'p' + str(target_version.protocol)
+                if not self.fw_installed.is_protocol_supported(device_name, git_protocol):
+                    click.secho('---------------------------', fg="yellow")
+                    click.secho(
+                        'Target firmware branch of %s is incompatible with installed Stretch Body for device %s' % (
+                        branch_name, device_name), fg="yellow")
+                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(
+                        *self.fw_installed.get_supported_protocols(device_name))
+                    click.secho('Installed Stretch Body supports protocols %s' % x, fg="yellow")
+                    click.secho('Target branch supports protocol %s' % git_protocol, fg="yellow")
+                    if git_protocol > self.fw_installed.max_protocol_supported(device_name):
+                        click.secho('Upgrade Stretch Body first...', fg="yellow")
+                    else:
+                        click.secho('Downgrade Stretch Body first...', fg="yellow")
+                    return False
+        return True
 
-        tag = None
-        repo_path=None
-
-        self.pretty_print_update_state()
-
-        #Advance the state machine
-        if args.no_prompts or click.confirm('Proceed with update??'):
-            #update_state is now filled out. Advance the states of all targets
-
-            #Flash all devices
-            for d in self.update_state['target']:
-                if d is not None and not self.update_state[d]['flash']:
-                    self.update_state[d]['flash']=self.do_device_flash(d,tag,repo_path,args.verbose)
-
-            if not self.all_pass('flash'):
-                click.secho('WARNING: Not all devices flashed successfully', fg="yellow", bold=True)
-                click.secho('WARNING: Reboot machine.', fg="yellow", bold=True)
-                click.secho('WARNING: Then run: REx_firmware_udpater.py - -resume')
-                return False
-
-            for d in self.update_state['target']:
-                if d is not None and not self.update_state[d]['return_to_bus']:
-                    self.update_state[d]['return_to_bus']=self.wait_on_return_to_bus(d)
-
-            if not self.all_pass('return_to_bus'):
-                click.secho('WARNING: Not all devices returned to bus successfully', fg="yellow", bold=True)
-                click.secho('WARNING: Reboot machine.', fg="yellow", bold=True)
-                click.secho('WARNING: Then run: REx_firmware_udpater.py - -resume')
-                return False
-
-            for d in self.update_state['target']:
-                if d is not None and not self.update_state[d]['version_validate']:
-                    self.update_state[d]['version_validate'] = self.verify_firmware_version(d)
-
-            if not self.all_pass('verify_firmware_version'):
-                click.secho('WARNING: Not all devices have updated to target firmware version', fg="yellow", bold=True)
-                click.secho('WARNING: Reboot machine.', fg="yellow", bold=True)
-                click.secho('WARNING: Then run: REx_firmware_udpater.py - -resume')
-                return False
-
-            for d in self.update_state['target']:
-                if d is not None and not self.update_state[d]['calibration_flash']:
-                    self.update_state[d]['calibration_flash'] = self.calibration_flash(d)
-
-
-            if 1:#all_success:
-                print('')
-                click.secho('----------------- Congratulations! ---------------.', fg="green", bold=True)
-                click.secho('No issues encountered. Firmware update successful.', fg="green", bold=True)
-
-    def pretty_print_update_state(self):
-        pass
-
-    def all_pass(self,state_name):
-        all_pass=True
-        for d in self.update_state['target']:
-            if d is not None:
-                all_pass=all_pass and self.update_state[d][state_name]
 
 # ########################################################################################################################
-    def wait_on_return_to_bus(self,device_name):
-        click.secho('Checking that device %s returned to bus '%device_name)
-        print('It may take several minutes to appear on the USB bus.' )
-        ts = time.time()
-        found = False
-        for i in range(30):
-            if not self.wait_on_device(device_name, timeout=10.0):
-                print('Trying again: %d\n' % i)
-                # Bit of a hack.Sometimes after a firmware flash the device
-                # Doesn't fully present on the USB bus with a serial No for Udev to find
-                # In does present as an 'Arduino Zero' product. This will attempt to reset it
-                # and re-present to the bus
-                # time.sleep(1.0)
-                # os.system('usbreset \"Arduino Zero\"')
-                # time.sleep(1.0)
-                print('')
-            else:
-                found = True
-                break
-        if not found:
-            click.secho('Device %s failed to return to bus after %f seconds.' % (device_name, time.time() - ts),fg="yellow", bold=True)
-            return False
-        else:
-            click.secho('Device %s returned to bus after %f seconds.' % (device_name, time.time() - ts),fg="green", bold=True)
-        return True
+
 
 # ########################################################################################################################
 #     def foo(self):
@@ -262,105 +613,10 @@ class FirmwareUpdater():
 #                 return all_success
 #         return True
 
-# ########################################################################################################################
-    def do_device_flash(self,device_name, tag,repo_path=None,verbose=False):
-        click.secho('-------- FIRMWARE FLASH %s | %s ------------'%(device_name,tag), fg="cyan", bold=True)
-        config_file = self.fw_available.repo_path + '/arduino-cli.yaml'
-
-        user_msg_log('Config: '+str(config_file), user_display=verbose)
-        user_msg_log('Repo: '+str(repo_path), user_display=verbose)
-
-        sketch_name=None
-        if device_name == 'hello-motor-left-wheel' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift':
-            sketch_name = 'hello_stepper'
-        if device_name == 'hello-wacc':
-            sketch_name = 'hello_wacc'
-        if device_name == 'hello-pimu':
-            sketch_name = 'hello_pimu'
-
-        if sketch_name=='hello_stepper' and not self.does_stepper_have_encoder_calibration_YAML(device_name):
-            print('Encoder data has not been stored for %s and may be lost. Aborting firmware flash.'%device_name)
-            return False
-
-        print('Looking for device %s on bus' % device_name)
-        if not self.wait_on_device(device_name, timeout=5.0):
-            print('Failure: Device not on bus.')
-            return False
-        port_name = self.get_port_name(device_name)
-        user_msg_log('Device: %s Port: %s'%(device_name,port_name), user_display=verbose)
-        if port_name is not None and sketch_name is not None:
-
-            print('Starting programming. This will take about 5s...')
-            if repo_path is None:
-                os.chdir(self.fw_available.repo_path)
-                os.system('git checkout '+tag+'>/dev/null 2>&1')
-                src_path=self.fw_available.repo_path
-            else:
-                src_path=repo_path
-
-            compile_command = 'arduino-cli compile --config-file %s --fqbn hello-robot:samd:%s %s/arduino/%s'%(config_file,sketch_name,src_path,sketch_name)
-            user_msg_log(compile_command,user_display=verbose)
-            c=Popen(shlex.split(compile_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
-            if type(c)==bytes:
-                c=c.decode("utf-8")
-            cc = c.split('\n')
-            user_msg_log(c, user_display=verbose)
-
-            # In version 0.18.x the last line after compile is: Sketch uses xxx bytes (58%) of program storage space. Maximum is yyy bytes.
-            #In version 0.24.x +this is now on line 0.
-            #Need a more robust way to determine successful compile. Works for now.
-            self.update_state[device_name]['compile']=(str(cc[0]).find('Sketch uses')!=-1)
-            if not self.update_state[device_name]['compile']:
-                print('Firmware failed to compile %s at %s' % (sketch_name,src_path))
-                return False
-            else:
-                print('Success in firmware compile')
 
 
-            upload_command = 'arduino-cli upload  --config-file %s -p /dev/%s --fqbn hello-robot:samd:%s %s/arduino/%s' % (config_file, port_name, sketch_name, src_path,sketch_name)
 
-            user_msg_log(upload_command,user_display=verbose)
-            u = Popen(shlex.split(upload_command), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read().strip()
-
-
-            if type(u) == bytes:
-                u=u.decode('utf-8')
-            uu = u.split('\n')
-            user_msg_log(u, user_display=False)
-            if verbose:
-                print(upload_command)
-                # Pretty print the result
-                for l in uu:
-                    k = l.split('\r')
-                    if len(k) == 1:
-                        print(k[0])
-                    else:
-                        for m in k:
-                            print(m)
-            success = uu[-1] == 'CPU reset.'
-
-            if not success:
-                print('Firmware flash. Failed to upload to %s' % (port_name))
-                return False
-            else:
-                print('Success in firmware flash.')
-                return True
-        else:
-            print('Firmware update %s. Failed to find device %s'%(tag,device_name))
-            return False
-
-    def save_update_state(self):
-        yaml.dump(self.update_state, '/tmp/firmware_updater_state.yaml', default_flow_style=False)
-    
-    def load_update_state(self):
-        #Return dict of update in process, None if none available
-        try:
-            with open('/tmp/firmware_updater_state.yaml', 'r') as s:
-                return yaml.load(s, Loader=yaml.FullLoader)
-        except IOError:
-            return None
-
-    def __create_arduino_config_file(self):
+    def create_arduino_config_file(self):
         arduino_config = {'board_manager': {'additional_urls': []},
                           'daemon': {'port': '50051'},
                           'directories': {'data': os.environ['HOME'] + '/.arduino15',
@@ -377,7 +633,7 @@ class FirmwareUpdater():
     def pretty_print_target(self):
         click.secho(' UPDATING FIRMWARE TO... '.center(110, '#'), fg="cyan", bold=True)
         for device_name in self.target:
-            if self.use_device[device_name]:
+            if self.state['use_device'][device_name]:
                 if not self.fw_installed.is_device_valid(device_name):
                     print('%s | No target available' % device_name.upper().ljust(25))
                 else:
@@ -392,6 +648,7 @@ class FirmwareUpdater():
                     else:
                         rec = 'Reinstalling %s' % self.target[device_name]
                     print('%s | %s ' % (device_name.upper().ljust(25), rec.ljust(40)))
+        print('')
 
     def print_upload_warning(self):
         click.secho('------------------------------------------------', fg="yellow", bold=True)
@@ -406,95 +663,11 @@ class FirmwareUpdater():
         click.secho('------------------------------------------------', fg="yellow", bold=True)
 
 
-    def flash_stepper_calibration(self, device_name):
-        if device_name == 'hello-motor-arm' or device_name == 'hello-motor-lift' or device_name == 'hello-motor-right-wheel' or device_name == 'hello-motor-left-wheel':
-            click.secho(' Flashing Stepper Calibration: %s '.center(110, '#') % device_name, fg="cyan", bold=True)
-            if not self.wait_on_device(device_name):
-                click.secho('Device %s failed to return to bus. Power cycle may be required.' % device_name, fg="red", bold=True)
-                return False
-            #time.sleep(1.0)
-            motor = stretch_body.stepper.Stepper('/dev/' + device_name)
-            motor.startup()
-            if not motor.hw_valid:
-                click.secho('Failed to startup stepper %s' % device_name, fg="red", bold=True)
-                return False
-            else:
-                print('Writing gains to flash...')
-                motor.write_gains_to_flash()
-                motor.push_command()
-                print('Gains written to flash')
-                print('')
-                print('Reading calibration data from YAML...')
-                data = motor.read_encoder_calibration_from_YAML()
-                print('Writing calibration data to flash...')
-                motor.write_encoder_calibration_to_flash(data)
-                print('Successful write of FLASH.')
-                self.wait_on_device(device_name)
-                motor.board_reset()
-                motor.push_command()
-                motor.transport.ser.close()
-                time.sleep(2.0)
-                self.wait_on_device(device_name)
-                print('Successful return of device to bus.')
-        return True
 
-    def do_update_to_branch(self, verbose=False, no_prompts=False):
-        # Return True if system was upgraded
-        # Return False if system was not upgraded / error happened
-        click.secho(' Select target branch '.center(60, '#'), fg="cyan", bold=True)
-        branches = self.fw_available.get_remote_branches()
-        for id in range(len(branches)):
-            print('%d: %s' % (id, branches[id]))
-        print('')
-        branch_name = None
-        while branch_name == None:
-            try:
-                id = click.prompt('Please enter desired branch id', default=0)
-            except click.exceptions.Abort:
-                return False
-            if id >= 0 and id < len(branches):
-                branch_name = branches[id]
-            else:
-                click.secho('Invalid ID', fg="red")
-        print('Selected branch %s' % branch_name)
-        # Check that version of target branch is compatible
-        for device_name in self.target:
-            if self.use_device[device_name]:
-                sketch_name = self.get_sketch_name(device_name)
-                target_version = self.get_firmware_version_from_git(sketch_name, branch_name)
-                self.target[device_name] = target_version
-                git_protocol = 'p' + str(target_version.protocol)
-                if not self.fw_installed.is_protocol_supported(device_name, git_protocol):
-                    click.secho('---------------------------', fg="yellow")
-                    click.secho(
-                        'Target firmware branch of %s is incompatible with installed Stretch Body for device %s' % (
-                        branch_name, device_name), fg="yellow")
-                    x = " , ".join(["{}"] * len(self.fw_installed.get_supported_protocols(device_name))).format(
-                        *self.fw_installed.get_supported_protocols(device_name))
-                    click.secho('Installed Stretch Body supports protocols %s' % x, fg="yellow")
-                    click.secho('Target branch supports protocol %s' % git_protocol, fg="yellow")
-                    if git_protocol > self.fw_installed.max_protocol_supported(device_name):
-                        click.secho('Upgrade Stretch Body first...', fg="yellow")
-                    else:
-                        click.secho('Downgrade Stretch Body first...', fg="yellow")
-                    return False
-        return self.do_update(verbose=verbose, no_prompts=no_prompts)
 
-    def verify_firmware_version(self,device_name):
-        fw_installed = FirmwareInstalled({device_name: True})  # Pull the currently installed system from fw
-        if not fw_installed.is_device_valid(device_name):  # Device may not have come back on bus
-            print('%s | No device available' % device_name.upper().ljust(25))
-            print('')
-            return False
-        else:
-            click.secho(' Confirming Firmware Updates '.center(110, '#'), fg="cyan", bold=True)
-            v_curr = fw_installed.get_version(device_name)  # Version that is now on the board
-            if v_curr == self.target[device_name]:
-                click.secho('%s | %s ' % (device_name.upper().ljust(25), 'Installed firmware matches target'.ljust(40)),fg="green")
-                return True
-            else:
-                click.secho('%s | %s ' % (device_name.upper().ljust(25), 'Firmware update failure!!'.ljust(40)),fg="red", bold=True)
-                return False
+
+
+
 
     def get_firmware_version_from_path(self,sketch_name,path):
         file_path = path+'/'+sketch_name+'/Common.h'

--- a/python/stretch_factory/firmware_utils.py
+++ b/python/stretch_factory/firmware_utils.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+import click
+import os
+from subprocess import Popen, PIPE
+import stretch_body.stepper
+import stretch_body.pimu
+import stretch_body.wacc
+import stretch_body.device
+import time
+import sys
+import stretch_body.device
+import stretch_body.hello_utils
+import shlex
+
+log_device = stretch_body.device.Device(req_params=False)
+
+def user_msg_log(msg, user_display=True, fg=None, bg=None, bold=False):
+    if user_display:
+        click.secho(str(msg), fg=fg, bg=bg, bold=bold)
+    log_device.logger.debug(str(msg))
+
+def __check_ubuntu_version():
+    res = Popen(shlex.split('cat /etc/lsb-release | grep DISTRIB_RELEASE'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read().strip(b'\n')
+    return res == b'DISTRIB_RELEASE=18.04'
+
+def __check_arduino_cli_install():
+    target_version = b'0.31.0'  # 0.18.3'
+    version = 'None'
+    res = Popen(shlex.split('arduino-cli version'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read()
+    do_install = False
+    if not (res[:11] == b'arduino-cli'):
+        do_install = True
+    else:
+        version = res[res.find(b'Version:') + 9:res.find(b' Commit')]
+        if version != target_version:
+            do_install = True
+    if do_install:
+        click.secho('WARNING:---------------------------------------------------------------------------------',
+                    fg="yellow", bold=True)
+        click.secho('WARNING: Compatible version of arduino_cli not installed. ', fg="yellow", bold=True)
+        click.secho('Requires version %s. Installed version of %s' % (target_version, version))
+        if click.confirm('Install now?'):
+            os.system(
+                'curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh -s %s' % target_version.decode(
+                    'utf-8'))
+            os.system('arduino-cli config init')
+            os.system('arduino-cli core install arduino:samd@1.6.21')
+            return True
+        else:
+            return False
+    return True
+
+
+
+def get_sketch_name(device_name):
+    if device_name=='hello-motor-left-wheel' or device_name=='hello-motor-right-wheel' or device_name=='hello-motor-arm' or device_name=='hello-motor-lift':
+        return 'hello_stepper'
+    if device_name == 'hello-wacc':
+        return 'hello_wacc'
+    if device_name == 'hello-pimu':
+        return 'hello_pimu'
+
+def exec_process(cmdline, silent, input=None, **kwargs):
+    """Execute a subprocess and returns the returncode, stdout buffer and stderr buffer.
+       Optionally prints stdout and stderr while running."""
+    try:
+        sub = Popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE,**kwargs)
+        stdout, stderr = sub.communicate(input=input)
+        returncode = sub.returncode
+        if not silent:
+            sys.stdout.write(stdout.decode('utf-8'))
+            sys.stderr.write(stderr.decode('utf-8'))
+    except OSError as e:
+        if e.errno == 2:
+            raise RuntimeError('"%s" is not present on this system' % cmdline[0])
+        else:
+            raise
+    if returncode != 0:
+        raise RuntimeError('Got return value %d while executing "%s", stderr output was:\n%s' % (
+        returncode, " ".join(cmdline), stderr.rstrip(b"\n")))
+    return stdout
+
+
+def is_device_present(device_name):
+    try:
+        exec_process(['ls', '/dev/'+device_name], True)
+        return True
+    except RuntimeError as e:
+        return False
+
+def wait_on_device(device_name,timeout=10.0):
+    #Wait for device to appear on bus for timeout seconds
+    print('Waiting for device %s to return to bus.'%device_name)
+    ts=time.time()
+    itr=0
+    while(time.time()-ts<timeout):
+        if is_device_present(device_name):
+            return True
+        itr=itr+1
+        if itr % 5 == 0:
+            sys.stdout.write('.')
+            sys.stdout.flush()
+        time.sleep(0.1)
+    return False
+
+def get_port_name(device_name):
+    try:
+        port_name = Popen(shlex.split("ls -l /dev/" + device_name), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read().strip().split()[-1]
+        if not type(port_name)==str:
+            port_name=port_name.decode('utf-8')
+        return port_name
+    except IndexError:
+        return None
+
+def does_stepper_have_encoder_calibration_YAML(device_name):
+    d=stretch_body.device.Device(req_params=False)
+    sn = d.robot_params[device_name]['serial_no']
+    fn = 'calibration_steppers/' + device_name + '_' + sn + '.yaml'
+    enc_data = stretch_body.hello_utils.read_fleet_yaml(fn)
+    return len(enc_data)!=0
+

--- a/python/stretch_factory/firmware_utils.py
+++ b/python/stretch_factory/firmware_utils.py
@@ -12,6 +12,7 @@ import sys
 import stretch_body.device
 import stretch_body.hello_utils
 import shlex
+import stretch_factory.hello_device_utils as hdu
 
 log_device = stretch_body.device.Device(req_params=False)
 
@@ -20,11 +21,11 @@ def user_msg_log(msg, user_display=True, fg=None, bg=None, bold=False):
         click.secho(str(msg), fg=fg, bg=bg, bold=bold)
     log_device.logger.debug(str(msg))
 
-def __check_ubuntu_version():
+def check_ubuntu_version():
     res = Popen(shlex.split('cat /etc/lsb-release | grep DISTRIB_RELEASE'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read().strip(b'\n')
     return res == b'DISTRIB_RELEASE=18.04'
 
-def __check_arduino_cli_install():
+def check_arduino_cli_install():
     target_version = b'0.31.0'  # 0.18.3'
     version = 'None'
     res = Popen(shlex.split('arduino-cli version'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read()
@@ -119,4 +120,21 @@ def does_stepper_have_encoder_calibration_YAML(device_name):
     fn = 'calibration_steppers/' + device_name + '_' + sn + '.yaml'
     enc_data = stretch_body.hello_utils.read_fleet_yaml(fn)
     return len(enc_data)!=0
+
+def get_device_protocols(device_name):
+    #return list like ['p0','p1']
+    s=get_sketch_name(device_name)
+    if s == 'hello_wacc':
+        import stretch_body.wacc
+        dd = stretch_body.wacc.Wacc()
+        return list(dd.supported_protocols.keys())
+    elif s == 'hello_pimu':
+        import stretch_body.pimu
+        dd = stretch_body.pimu.Pimu()
+        return list(dd.supported_protocols.keys())
+    elif s == 'hello_stepper':
+        import stretch_body.stepper
+        dd = stretch_body.stepper.Stepper('/dev/'+device_name)
+        return list(dd.supported_protocols.keys())
+    return []
 

--- a/python/stretch_factory/firmware_version.py
+++ b/python/stretch_factory/firmware_version.py
@@ -1,0 +1,88 @@
+
+class FirmwareVersion():
+    """
+    Manage comparision of firmware versions
+    """
+
+    def __init__(self, version_str):
+        self.device = 'NONE'
+        self.major = 0
+        self.minor = 0
+        self.bugfix = 0
+        self.protocol = 0
+        self.valid = False
+        self.from_string(version_str)
+
+    def __str__(self):
+        return self.to_string()
+
+    def to_string(self):
+        """
+        Version is represented as Stepper.v0.0.1p0 for example
+        """
+        return self.device + '.v' + str(self.major) + '.' + str(self.minor) + '.' + str(self.bugfix) + 'p' + str(
+            self.protocol)
+
+    def __gt__(self, other):
+        if not self.valid or not other.valid:
+            return False
+        if self.protocol > other.protocol:
+            return True
+        if self.protocol < other.protocol:
+            return False
+        if self.major > other.major:
+            return True
+        if self.minor > other.minor:
+            return True
+        if self.bugfix > other.bugfix:
+            return True
+        return False
+
+    def __lt__(self, other):
+        if not self.valid or not other.valid:
+            return False
+        if self.protocol < other.protocol:
+            return True
+        if self.protocol > other.protocol:
+            return False
+        if self.major < other.major:
+            return True
+        if self.minor < other.minor:
+            return True
+        if self.bugfix < other.bugfix:
+            return True
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __eq__(self, other):
+        if not other or not self.valid or not other.valid:
+            return False
+        return self.major == other.major and self.minor == other.minor and self.bugfix == other.bugfix and self.protocol == other.protocol
+
+    def same_device(self, d):
+        return d == self.device
+
+    def from_string(self, x):
+        # X is of form 'Stepper.v0.0.1p0'
+        try:
+            xl = x.split('.')
+            if len(xl) != 4:
+                raise Exception('Invalid version len')
+            device = xl[0]
+            if not (device == 'Stepper' or device == 'Wacc' or device == 'Pimu'):
+                raise Exception('Invalid device name ')
+            major = int(xl[1][1:])
+            minor = int(xl[2])
+            bugfix = int(xl[3][0:xl[3].find('p')])
+            protocol = int(xl[3][(xl[3].find('p') + 1):])
+            self.device = device
+            self.major = major
+            self.minor = minor
+            self.bugfix = bugfix
+            self.protocol = protocol
+            self.valid = True
+        except(ValueError, Exception):
+            print('Invalid version format in tag: %s' % x)
+

--- a/python/stretch_factory/hello_device_utils.py
+++ b/python/stretch_factory/hello_device_utils.py
@@ -13,6 +13,7 @@ import usb.core
 import stretch_body.hello_utils as hello_utils
 import stretch_body.robot_params
 import stretch_body.device
+import serial
 
 
 # ###################################
@@ -158,6 +159,23 @@ def find_steppers_on_bus():
 
 
 # ###################################
+
+def place_arduino_in_bootloader(port):
+    print('Putting %s into bootloader mode.'%port)
+    arduino = serial.Serial(port, baudrate=1200)
+    with arduino:  # the reset part is actually optional but the sleep is nice to have either way.
+        arduino.setDTR(False)
+        time.sleep(0.1)
+        arduino.flushInput()
+        arduino.setDTR(True)
+        time.sleep(0.1)
+        arduino.setDTR(False)
+        time.sleep(0.1)
+        arduino.flushInput()
+        arduino.setDTR(True)
+        time.sleep(0.5)
+
+
 def find_arduinos():
     devs = []
     all = usb.core.find(find_all=True)

--- a/python/stretch_factory/hello_device_utils.py
+++ b/python/stretch_factory/hello_device_utils.py
@@ -283,18 +283,21 @@ def burn_bootloader(sketch):
 
 def reset_arduino_usb():
     USBDEVFS_RESET = 21780
-    lsusb_out = Popen("lsusb | grep -i %s" % 'Arduino', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,
-                      close_fds=True).stdout.read().strip().split()
-    while len(lsusb_out):
-        bus = lsusb_out[1]
-        device = lsusb_out[3][:-1]
+    lsusb_out = Popen("lsusb | grep -i Arduino", shell=True, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read()
+    if type(lsusb_out)==bytes:
+        lsusb_out=lsusb_out.decode('utf-8')
+    lsusb_out=lsusb_out.strip().split('\n')
+    for d in lsusb_out:
+        dd=d.split(' ')
+        bus = dd[1]
+        device = dd[3][:-1]
         try:
             print('Resetting Arduino. Bus:', bus, 'Device: ', device)
             f = open("/dev/bus/usb/%s/%s" % (bus, device), 'w', os.O_WRONLY)
             fcntl.ioctl(f, USBDEVFS_RESET, 0)
         except Exception as msg:
             print("failed to reset device: %s" % msg)
-        lsusb_out = lsusb_out[8:]
+
 
 
 # ##############################################################

--- a/python/stretch_factory/hello_device_utils.py
+++ b/python/stretch_factory/hello_device_utils.py
@@ -118,6 +118,26 @@ def get_all_ttyACMx():
             ret.append(l[5:])
     return ret
 
+def get_hello_ttyACMx_mapping():
+    mapping={}
+    mapping['hello'] = {'hello-motor-arm': None, 'hello-motor-right-wheel': None, 'hello-motor-left-wheel': None,'hello-pimu': None, 'hello-wacc': None, 'hello-motor-lift': None}
+    mapping['missing']=[]
+    mapping['ACMx']={}
+
+    for d in mapping['hello']:
+        x = get_device_ttyACMx('/dev/'+d)
+        if x is not None:
+            mapping['hello'][d] = x
+        else:
+            mapping['missing'].append(d)
+
+    att = get_all_ttyACMx()
+    for a in att:
+        mapping['ACMx'][a]=None
+        for h in mapping['hello']:
+            if mapping['hello'][h]==a:
+                mapping['ACMx'][a]=h
+    return mapping
 
 def is_device_present(device):
     try:

--- a/python/tools/REx_firmware_flash.py
+++ b/python/tools/REx_firmware_flash.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+from stretch_factory.hello_device_utils import compile_arduino_firmware, burn_arduino_firmware
+import os.path
+import sys
+import argparse
+import time
+import stretch_body.hello_utils as hu
+from stretch_factory.firmware_available import FirmwareAvailable
+from colorama import Fore, Style
+import stretch_body.device
+import click
+import stretch_factory.hello_device_utils as hdu
+import serial
+
+hu.print_stretch_re_use()
+
+use_device = {'hello-motor-arm': False, 'hello-motor-right-wheel': False, 'hello-motor-left-wheel': False,
+              'hello-pimu': False, 'hello-wacc': False, 'hello-motor-lift': False}
+
+#Note: This is a simple alternative to REx_firmware_updater.py
+parser = argparse.ArgumentParser(description='Tool to directly flash Stretch firmware to a ttyACM device', )
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--map", help="Print mapping from ttyACMx to Hello devices", action="store_true")
+group.add_argument('--flash', nargs=2, type=str, help='Flash firmware. E.g, --flash /dev/ttyACM0 hello-motor-arm')
+group.add_argument('--boot', nargs=1, type=str, help='Place board in bootloader mode. E.g, --reset /dev/ttyACM0')
+
+
+args = parser.parse_args()
+
+
+def does_stepper_have_encoder_calibration_YAML(device_name):
+    d = stretch_body.device.Device(req_params=False)
+    sn = d.robot_params[device_name]['serial_no']
+    fn = 'calibration_steppers/' + device_name + '_' + sn + '.yaml'
+    enc_data = stretch_body.hello_utils.read_fleet_yaml(fn)
+    return len(enc_data) != 0
+
+if args.boot:
+    hdu.place_arduino_in_bootloader(args.boot[0])
+    exit()
+
+if args.map:
+    mapping = hdu.get_hello_ttyACMx_mapping()
+    click.secho('------------------------------------------', fg="yellow", bold=True)
+    for k in mapping['hello']:
+        print('%s | %s' % (k, mapping['hello'][k]))
+    click.secho('------------------------------------------', fg="yellow", bold=True)
+    for k in mapping['ACMx']:
+        print('%s | %s' % (k, mapping['ACMx'][k]))
+    click.secho('------------------------------------------', fg="yellow", bold=True)
+    print('')
+    exit()
+
+if args.flash:
+    port = args.flash[0]
+    device = args.flash[1]
+    a = FirmwareAvailable({device: True})
+    if "hello-motor" in device:
+        sketch_name = 'hello_stepper'
+        if not does_stepper_have_encoder_calibration_YAML(device):
+            print(Style.BRIGHT + Fore.YELLOW + f"WARNING: Encoder calibration data hasn't been stored. Storing it before proceeding" + Style.RESET_ALL)
+            os.system(f"REx_stepper_calibration_flash_to_YAML.py {device}")
+            time.sleep(3)
+
+    elif "hello-pimu" in device:
+        sketch_name = 'hello_pimu'
+    elif "hello-wacc" in device:
+        sketch_name = 'hello_wacc'
+    else:
+        print(Fore.RED + 'Invalid Device name')
+        sys.exit()
+
+    repo_path = os.path.expanduser('~/repos/stretch_firmware')
+    if not os.path.exists(repo_path):
+        print('Firmware not present')
+        print('Clone https://github.com/hello-robot/stretch_firmware to ~/repos/stretch_firmware first')
+        sys.exit()
+    t = 'Choose a Firmware Version'
+    print(Style.BRIGHT + t)
+    print('=' * len(t))
+    i = 0
+    for v in a.versions[device]:
+        v_s = v.to_string()
+        print(f"[{i}] {v_s}")
+        i = i + 1
+    print('-' * len(t))
+    x = input("Enter Version:")
+    version = a.versions[device][i - 1].to_string()
+    print(f"\nChoosen version: {version}" + Style.RESET_ALL)
+    sys.stdout.write('.')
+    sys.stdout.flush()
+    os.system(f"cd {repo_path}; git pull; git checkout tags/{version}")
+
+    if compile_arduino_firmware(sketch_name, repo_path):
+        print(Fore.GREEN + f"Compiled Arduino Sketch:{sketch_name} Successfully." + Style.RESET_ALL)
+        hdu.place_arduino_in_bootloader(port)
+        time.sleep(1.0)
+        if burn_arduino_firmware(port, sketch_name, repo_path):
+            print(Fore.GREEN + f"Burned Arduino Sketch:{sketch_name} Successfully to port:{port}." + Style.RESET_ALL)
+            if sketch_name == 'hello_stepper' and 'hello-' in port:
+                time.sleep(3)
+                os.system(f"REx_stepper_calibration_YAML_to_flash.py {device}")
+        else:
+            print(Fore.RED + f"Failed to burn Arduino Sketch:{sketch_name} to port:{port}." + Style.RESET_ALL)
+    else:
+        print(Fore.RED + f"Failed to compile Arduino Sketch:{sketch_name}." + Style.RESET_ALL)

--- a/python/tools/REx_firmware_updater.py
+++ b/python/tools/REx_firmware_updater.py
@@ -17,6 +17,7 @@ group.add_argument("--install_version", help="Install a specific firmware versio
 group.add_argument("--install_branch", help="Install the HEAD of a specific branch", action="store_true")
 group.add_argument("--install_path", help="Install the firmware on the provided path (eg ./stretch_firmware/arduino)", type=str)
 group.add_argument("--resume", help="Resume an install in progress", action="store_true")
+parser.add_argument("--zombie", help="Attempt to recover zombie device", action="store_true")
 group.add_argument("--mgmt", help="Display overview on firmware management", action="store_true")
 
 parser.add_argument("--pimu", help="Upload Pimu firmware", action="store_true")
@@ -112,10 +113,9 @@ if args.available:
     a.pretty_print()
     exit()
 
-if args.resume or args.install or args.install_version or args.install_branch or args.install_path:
+
+if args.resume or args.install or args.install_version or args.install_branch or args.install_path or args.zombie:
     u = FirmwareUpdater(use_device, args)
-    if not u.startup():
-        exit()
     u.run()
 else:
     parser.print_help()

--- a/python/tools/REx_firmware_updater.py
+++ b/python/tools/REx_firmware_updater.py
@@ -1,6 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
-from stretch_factory.firmware_updater import *
+from stretch_factory.firmware_available import FirmwareAvailable
+from stretch_factory.firmware_recommended import FirmwareRecommended
+from stretch_factory.firmware_installed import FirmwareInstalled
+from stretch_factory.firmware_updater import FirmwareUpdater
 import os
 
 parser = argparse.ArgumentParser(description='Upload Stretch firmware to microcontrollers')
@@ -13,6 +16,7 @@ group.add_argument("--install", help="Install the recommended firmware", action=
 group.add_argument("--install_version", help="Install a specific firmware version", action="store_true")
 group.add_argument("--install_branch", help="Install the HEAD of a specific branch", action="store_true")
 group.add_argument("--install_path", help="Install the firmware on the provided path (eg ./stretch_firmware/arduino)", type=str)
+group.add_argument("--resume", help="Resume an install in progress", action="store_true")
 group.add_argument("--mgmt", help="Display overview on firmware management", action="store_true")
 
 parser.add_argument("--pimu", help="Upload Pimu firmware", action="store_true")
@@ -93,40 +97,26 @@ if args.mgmt:
     exit()
 
 if args.current:
-    c = InstalledFirmware(use_device)
+    c = FirmwareInstalled(use_device)
     c.pretty_print()
     exit()
 
 if args.recommended:
-    r = RecommendedFirmware(use_device)
+    r = FirmwareRecommended(use_device)
     r.pretty_print()
     r.print_recommended_args()
     exit()
 
 if args.available:
-    a = AvailableFirmware(use_device)
+    a = FirmwareAvailable(use_device)
     a.pretty_print()
     exit()
 
-if args.install or args.install_version or args.install_branch or args.install_path:
-    cwd=os.getcwd()
-    u = FirmwareUpdater(use_device)
+if args.resume or args.install or args.install_version or args.install_branch or args.install_path:
+    u = FirmwareUpdater(use_device, args)
     if not u.startup():
         exit()
-    if args.install:
-        u.fw_recommended.pretty_print()
-        print('')
-        print('')
-        u.do_update(no_prompts=args.no_prompts,verbose=args.verbose)
-    elif args.install_version:
-        u.do_update_to(verbose=args.verbose)
-    elif args.install_branch:
-        u.do_update_to_branch(verbose=args.verbose)
-    elif args.install_path:
-        if args.install_path[0]!='/':
-            u.do_update_to_path(cwd+'/'+args.install_path,verbose=args.verbose)
-        else:
-            u.do_update_to_path(args.install_path,verbose=args.verbose)
+    u.run()
 else:
     parser.print_help()
 

--- a/python/tools/REx_firmware_updater.py
+++ b/python/tools/REx_firmware_updater.py
@@ -5,6 +5,8 @@ from stretch_factory.firmware_recommended import FirmwareRecommended
 from stretch_factory.firmware_installed import FirmwareInstalled
 from stretch_factory.firmware_updater import FirmwareUpdater
 import os
+import click
+import stretch_factory.hello_device_utils as hdu
 
 parser = argparse.ArgumentParser(description='Upload Stretch firmware to microcontrollers')
 
@@ -18,6 +20,7 @@ group.add_argument("--install_branch", help="Install the HEAD of a specific bran
 group.add_argument("--install_path", help="Install the firmware on the provided path (eg ./stretch_firmware/arduino)", type=str)
 group.add_argument("--resume", help="Resume an install in progress", action="store_true")
 group.add_argument("--mgmt", help="Display overview on firmware management", action="store_true")
+parser.add_argument("--map", help="Print mapping from ttyACMx to Hello device", action="store_true")
 
 parser.add_argument("--pimu", help="Upload Pimu firmware", action="store_true")
 parser.add_argument("--wacc", help="Upload Wacc firmware", action="store_true")
@@ -96,6 +99,18 @@ if args.mgmt:
     print(mgmt)
     exit()
 
+if args.map:
+        mapping = hdu.get_hello_ttyACMx_mapping()
+        click.secho('------------------------------------------', fg="yellow", bold=True)
+        for k in mapping['hello']:
+            print('%s | %s' % (k, mapping['hello'][k]))
+        click.secho('------------------------------------------', fg="yellow", bold=True)
+        for k in mapping['ACMx']:
+            print('%s | %s' % (k, mapping['ACMx'][k]))
+        click.secho('------------------------------------------', fg="yellow", bold=True)
+        print('')
+        exit()
+
 if args.current:
     c = FirmwareInstalled(use_device)
     c.pretty_print()
@@ -116,6 +131,7 @@ if args.available:
 if args.resume or args.install or args.install_version or args.install_branch or args.install_path:
     u = FirmwareUpdater(use_device, args)
     u.run()
+    exit()
 else:
     parser.print_help()
 

--- a/python/tools/REx_firmware_updater.py
+++ b/python/tools/REx_firmware_updater.py
@@ -17,7 +17,6 @@ group.add_argument("--install_version", help="Install a specific firmware versio
 group.add_argument("--install_branch", help="Install the HEAD of a specific branch", action="store_true")
 group.add_argument("--install_path", help="Install the firmware on the provided path (eg ./stretch_firmware/arduino)", type=str)
 group.add_argument("--resume", help="Resume an install in progress", action="store_true")
-parser.add_argument("--zombie", help="Attempt to recover zombie device", action="store_true")
 group.add_argument("--mgmt", help="Display overview on firmware management", action="store_true")
 
 parser.add_argument("--pimu", help="Upload Pimu firmware", action="store_true")
@@ -114,7 +113,7 @@ if args.available:
     exit()
 
 
-if args.resume or args.install or args.install_version or args.install_branch or args.install_path or args.zombie:
+if args.resume or args.install or args.install_version or args.install_branch or args.install_path:
     u = FirmwareUpdater(use_device, args)
     u.run()
 else:


### PR DESCRIPTION
This PR refactors the REx_firmware tools:

TLDR: The REx_firmware_updater.py was refactored to be more reliable. It still isn’t perfect but should avoid many of the failures we’ve seen before

This release:

Reorged state flow so that each joint is done independently
Added –resume flag that stores the state and allows for a power cycle mid-process
Added ability to reset / place board in bootloader using DTR flag
Added –map flag so user can see which devices aren’t correctly mapped
Added a retry to the flash step as if get a DTR error often it will work the next time
Added a long retry period for waiting on return to bus. Will often return after 5-6 tries.
Added REx_firmware_flash.py tool that allows for just flashing a single device from the command line
