### PR TITLE
Stop device trnasport after verifying fw version, Update arduino cli …

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ stretch_scripts=[f for f in ex_scripts if isfile(f)]
 
 setuptools.setup(
     name="hello_robot_stretch_factory",
-    version="0.4.6",
+    version="0.4.7",
     author="Hello Robot Inc.",
     author_email="support@hello-robot.com",
     description="Stretch Factory Tools",

--- a/python/stretch_factory/firmware_updater.py
+++ b/python/stretch_factory/firmware_updater.py
@@ -470,6 +470,10 @@ class FirmwareUpdater():
         if not dd.startup():
             click.secho('FAIL: Unable to establish comms with device %s' % device_name.upper(), fg="red")
             return False
+        else:
+            time.sleep(0.5)
+            dd.stop()
+            del dd
         click.secho('PASS: Established comms with device %s ' % device_name.upper(),fg="green")
         return True
 # ########################################################################################################3
@@ -645,11 +649,16 @@ class FirmwareUpdater():
 
 
     def create_arduino_config_file(self):
+        if  self.state['install_path']:
+            user_path = self.state['install_path']
+        else:
+            user_path = self.fw_available.repo_path + '/arduino'
+       
         arduino_config = {'board_manager': {'additional_urls': []},
                           'daemon': {'port': '50051'},
                           'directories': {'data': os.environ['HOME'] + '/.arduino15',
                                           'downloads': os.environ['HOME'] + '/.arduino15/staging',
-                                          'user': self.fw_available.repo_path + '/arduino'},
+                                          'user': user_path},
                           'library': {'enable_unsafe_install': False},
                           'logging': {'file': '', 'format': 'text', 'level': 'info'},
                           'metrics': {'addr': ':9090', 'enabled': True},


### PR DESCRIPTION
Fix firmware_updater bugs:

- User path not updated to the arduino-cli config file while using --install_path tag
- Stretch body device instance not stopped/relieve the USB port after verifying the communication causing other instances unable to create a connection.