### PR TITLE
Respect the no_prompt flag during arduino-cli install

### DIFF
--- a/python/stretch_factory/firmware_updater.py
+++ b/python/stretch_factory/firmware_updater.py
@@ -104,7 +104,7 @@ class FirmwareUpdater():
         self.fw_recommended = FirmwareRecommended(self.state['use_device'], self.fw_installed, self.fw_available)
 
         self.create_arduino_config_file()
-        self.ready_to_run = fwu.check_arduino_cli_install()
+        self.ready_to_run = fwu.check_arduino_cli_install(self.state['no_prompts'])
 
         # Set the target version to flash to recommended for each device
         #This dict has a FirmwareVersion target for each device that has a valid (and desired) update

--- a/python/stretch_factory/firmware_utils.py
+++ b/python/stretch_factory/firmware_utils.py
@@ -25,7 +25,7 @@ def check_ubuntu_version():
     res = Popen(shlex.split('cat /etc/lsb-release | grep DISTRIB_RELEASE'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read().strip(b'\n')
     return res == b'DISTRIB_RELEASE=18.04'
 
-def check_arduino_cli_install():
+def check_arduino_cli_install(no_prompts=False):
     target_version = b'0.31.0'  # 0.18.3'
     version = 'None'
     res = Popen(shlex.split('arduino-cli version'), shell=False, bufsize=64, stdin=PIPE, stdout=PIPE,close_fds=True).stdout.read()
@@ -41,12 +41,13 @@ def check_arduino_cli_install():
                     fg="yellow", bold=True)
         click.secho('WARNING: Compatible version of arduino_cli not installed. ', fg="yellow", bold=True)
         click.secho('Requires version %s. Installed version of %s' % (target_version, version))
-        if click.confirm('Install now?'):
+        if no_prompts or click.confirm('Install now?'):
             os.system(
                 'curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=$HOME/.local/bin/ sh -s %s' % target_version.decode(
                     'utf-8'))
-            os.system('arduino-cli config init')
+            os.system('arduino-cli config init --overwrite')
             os.system('arduino-cli core install arduino:samd@1.6.21')
+            os.system("sed -i -e 's#Arduino#repos/stretch_firmware/arduino#g' ~/.arduino15/arduino-cli.yaml")
             return True
         else:
             return False

--- a/python/stretch_factory/hello_device_utils.py
+++ b/python/stretch_factory/hello_device_utils.py
@@ -62,22 +62,6 @@ def check_internet():
 
 
 # ###################################
-def check_arduino_cli_install():
-    """
-    Return true if the arduino-cli is available
-    """
-    res = Popen('arduino-cli version', shell=True, bufsize=64, stdin=PIPE, stdout=PIPE, close_fds=True).stdout.read()[
-          :11]
-    if not (res == b'arduino-cli'):
-        print('WARNING:---------------------------------------------------------------------------------')
-        print('WARNING: Tool arduino_cli not installed. See stretch_install_dev.sh (Stretch Install repo)')
-        print('WARNING:---------------------------------------------------------------------------------')
-        print('')
-        return False
-    return True
-
-
-# ###################################
 def exec_process(cmdline, silent, input=None, **kwargs):
     """Execute a subprocess and returns the returncode, stdout buffer and stderr buffer.
        Optionally prints stdout and stderr while running."""

--- a/python/tools/REx_firmware_updater.py
+++ b/python/tools/REx_firmware_updater.py
@@ -130,8 +130,8 @@ if args.available:
 
 if args.resume or args.install or args.install_version or args.install_branch or args.install_path:
     u = FirmwareUpdater(use_device, args)
-    u.run()
-    exit()
+    success = u.run()
+    exit(0 if success else 1)
 else:
     parser.print_help()
 


### PR DESCRIPTION
This PR makes the arduino-cli install happen quietly when using the `--no_prompt` flag from `REx_firmware_updater.py`. Also, it has has the tool exit with code 1 if the tool fails to perform the install. Lastly, a duplicate version of a method called `check_arduino_cli_install()` is deleted.