### PR TITLE
Support stepper types in the Firmware Updater tool

### DIFF
--- a/python/tools/REx_stepper_type.py
+++ b/python/tools/REx_stepper_type.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import stretch_body.stepper as stepper
+import stretch_body.pimu as pimu
+import stretch_body.hello_utils as hu
+import argparse
+import time
+
+
+motor_names = ['hello-motor-left-wheel', 'hello-motor-right-wheel', 'hello-motor-arm', 'hello-motor-lift']
+parser = argparse.ArgumentParser(description='Read and write stepper type to/from flash memory of stepper boards')
+group2 = parser.add_mutually_exclusive_group(required=True)
+group2.add_argument("--read", help="Read the current stepper type from flash",action="store_true")
+group2.add_argument("--write", help="Write stepper_type to stepper flash",action="store_true")
+args = parser.parse_args()
+
+
+def stepper_type():
+    for i in motor_names:
+        motor = stepper.Stepper(f'/dev/{i}')
+        for x in motor.supported_protocols.keys():
+            recent_protocol = x.strip('p')
+        if int(recent_protocol) >= 5:
+            if not motor.startup():
+                print(f"Error with communication to {i}")
+                exit(1)
+
+            if motor.board_info['protocol_version'] == 'p5':
+                if args.write:
+                    print(f"Now setting {i} stepper type to flash...")
+                    motor.write_stepper_type_to_flash(i)
+                    time.sleep(1)
+                    motor.read_stepper_type_from_flash()
+                    if i == motor.board_info['stepper_type']:
+                        print(f"Success {i} stepper type to flash\n")
+                    else:
+                        print(f"Error setting stepper type to {i}, please try again\n")
+                    motor.stop()
+                    time.sleep(1)
+
+                if args.read:
+                    print(f"Now reading stepper_type from {i}....")
+                    motor.read_stepper_type_from_flash()
+                    time.sleep(1)
+
+                    print(f"stepper_type == {motor.board_info['stepper_type']}\n")
+                    time.sleep(1)
+                    motor.stop()
+            else:
+                print(f"Protocol version for {i} is incorrect please update firmware to proper version")
+                exit(1)
+
+        elif int(recent_protocol) < 5:
+            print("Stretch Body Protocol Version is below p5 please update Stretch Body")
+            exit(1)
+
+stepper_type()
+


### PR DESCRIPTION
This PR introduces the concept of "stepper types" to the Stretch Factory package. In [P5 firmware](https://github.com/hello-robot/stretch_firmware/pull/25), @vrathiraj-hellorobot introduced the ability for the uC on a stepper PCB to know which kind of stepper it is (i.e. arm, lift, right wheel, left wheel). In this PR, the firmware updater checks if the stepper already knows its stepper type before erasing the flash memory through a new firmware flash. It saves the stepper_type, flashes the new firmware, then writes the stepper_type to flash memory. This PR also introduces the new tool called `REx_stepper_type.py` tool for Hello Robot support members to be able to assist Stretch users in flashing their stepper_type bits.

There's a couple benefits to each stepper knowing its stepper_type at the firmware level:
1. The wheels on newer Stretch robots can take advantage of better runstop by actually disconnecting the H bridge from the motor. This makes it easier to backdrive the robot around by tilting the robot and pushing it like a vacuum cleaner.
2. The system check tool can verify that the UDEV rules for each stepper agree with the stepper_type of the stepper. In case the UDEV rules get corrupted, this provides an additional level of redundancy. 