### PR TITLE
Xrandr Python Tool

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -26,6 +26,6 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
     ],
 
-    install_requires=['future', 'pyserial','pyusb','gitpython','hello-robot-stretch-body>=0.4.26','tabulate']
+    install_requires=['future', 'pyserial','pyusb','gitpython','hello-robot-stretch-body>=0.4.26','tabulate', 'python-xlib']
 
 )

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -70,14 +70,20 @@ def get_display_info():
         print(f'Error: This tool only supports 1 display. There are {len(result)} plugged in')
         sys.exit(1)
 
-    return result[0]
+    oresult = result[0]
+    oresult['available_resolutions'].sort(key=lambda val: int(val.split('x')[0]))
+
+    return oresult
 
 if args['current']:
     info = get_display_info()
     print(f"Display Name:       {info['name']}")
     print(f"Display Resolution: {info['resolution']}")
 elif args['list']:
-    print('okay')
+    info = get_display_info()
+    print("Available Resolutions:")
+    for r in info['available_resolutions']:
+        print(r)
 else:
     print('oh no')
 

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -11,7 +11,7 @@ from Xlib.ext import randr
 parser = argparse.ArgumentParser(
     description="Tool to change display resolution/fps/etc.."
 )
-group = parser.add_mutually_exclusive_group(required=True)
+group = parser.add_mutually_exclusive_group(required=False)
 group.add_argument('--set', type=str, help='Set resolution to WIDTHxHEIGHTxFPS. E.g. --set 1920x1080x60.00')
 group.add_argument('--set-720p', action='store_true', help='Set resolution to 1280x720xhighest_fps')
 group.add_argument('--set-1080p', action='store_true', help='Set resolution to 1920x1080xhighest_fps')
@@ -84,6 +84,23 @@ elif args['list']:
     print("Available Resolutions:")
     for r in info['available_resolutions']:
         print(r)
+elif args['set']:
+    desired_resolution = args['set']
+    dr_parts = desired_resolution.split('x')
+    if len(dr_parts) != 3:
+        print('Error: Resolution should have 3 parts. E.g. 1920x1080x60.00')
+        sys.exit(1)
+    info = get_display_info()
+    if desired_resolution not in info['available_resolutions']:
+        closest_resolution = '1920x1080x60.00'
+        width_match_resolutions = [wmr for wmr in info['available_resolutions'] if dr_parts[0] in wmr]
+        closest_resolution = width_match_resolutions[0] if len(width_match_resolutions) > 0 else closest_resolution
+        wh_match_resolutions = [whmr for whmr in info['available_resolutions'] if f"{dr_parts[0]}x{dr_parts[1]}" in whmr]
+        closest_resolution = wh_match_resolutions[0] if len(wh_match_resolutions) > 0 else closest_resolution
+        print(f'Warning: Desired resolution not available. Picking closest: {closest_resolution}')
+        desired_resolution = closest_resolution
+
+    print(desired_resolution)
 else:
-    print('oh no')
+    parser.print_help()
 

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -143,7 +143,33 @@ elif args['set']:
     new_info = get_display_info()
     if new_info['resolution'] != desired_resolution:
         print("Warning: Issued xrandr request, but the resolution doesn't seem to have change")
-    save_display_info(info)
+    save_display_info(old_info)
+elif args['set_720p']:
+    desired_resolution = '1280x720x60.00'
+    info = get_display_info()
+    if desired_resolution not in info['available_resolutions']:
+        print('Error: 720p resolution not available')
+        sys.exit(1)
+    issue_xrandr_command(info['name'], desired_resolution)
+
+    old_info = info
+    new_info = get_display_info()
+    if new_info['resolution'] != desired_resolution:
+        print("Warning: Issued xrandr request, but the resolution doesn't seem to have change")
+    save_display_info(old_info)
+elif args['set_1080p']:
+    desired_resolution = '1920x1080x60.00'
+    info = get_display_info()
+    if desired_resolution not in info['available_resolutions']:
+        print('Error: 1080p resolution not available')
+        sys.exit(1)
+    issue_xrandr_command(info['name'], desired_resolution)
+
+    old_info = info
+    new_info = get_display_info()
+    if new_info['resolution'] != desired_resolution:
+        print("Warning: Issued xrandr request, but the resolution doesn't seem to have change")
+    save_display_info(old_info)
 else:
     parser.print_help()
 

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import stretch_body.hello_utils as hu
+hu.print_stretch_re_use()
+
+import sys
+import argparse
+from Xlib import display
+from Xlib.ext import randr
+
+parser = argparse.ArgumentParser(
+    description="Tool to change display resolution/fps/etc.."
+)
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--set', type=str, help='Set resolution to WIDTHxHEIGHTxFPS. E.g. --set 1920x1080x60.00')
+group.add_argument('--set-720p', action='store_true', help='Set resolution to 1280x720xhighest_fps')
+group.add_argument('--set-1080p', action='store_true', help='Set resolution to 1920x1080xhighest_fps')
+group.add_argument('--revert', action='store_true', help='Revert resolution to whatever it was before --set was called. Does nothing if prev resolution not saved or cleared with reboot.')
+group.add_argument('--list', action='store_true', help='List all available resolutions for the display')
+group.add_argument('--current', action='store_true', help='Print out the current resolution being used')
+args = vars(parser.parse_args())
+
+def find_mode(id, modes):
+    for mode in modes:
+        if id == mode.id:
+            return f"{mode.width}x{mode.height}x{mode.dot_clock / (mode.h_total * mode.v_total)}"
+
+def get_display_info():
+    try:
+        d = display.Display(':0')
+    except:
+        print('Error: No display available')
+        sys.exit(1)
+
+    screen_count = d.screen_count()
+    if screen_count == 0:
+        print('Error: No display plugged in')
+        sys.exit(1)
+    elif screen_count != 1:
+        print(f'Error: This tool only supports 1 display. There are {screen_count} plugged in')
+        sys.exit(1)
+
+    s = d.screen(0)
+    window = s.root
+    res = randr.get_screen_resources(window)
+    result = []
+    for output in res.outputs:
+        params = d.xrandr_get_output_info(output, res.config_timestamp)
+        if not params.crtc:
+            continue
+        crtc = d.xrandr_get_crtc_info(params.crtc, res.config_timestamp)
+        crtc_resolution = f"{crtc.width}x{crtc.height}"
+        crtc_mode = find_mode(crtc.mode, res.modes)
+        if crtc_mode == None or crtc_resolution not in crtc_mode:
+            print('Error: Unable to find resolution mode for current display')
+            sys.exit(1)
+        modes = set()
+        for mode in params.modes:
+            modes.add(find_mode(mode, res.modes))
+        result.append({
+            'name': params.name,
+            'resolution': crtc_mode,
+            'available_resolutions': list(modes),
+        })
+
+    if len(result) == 0:
+        print('Error: No display plugged in')
+        sys.exit(1)
+    elif len(result) != 1:
+        print(f'Error: This tool only supports 1 display. There are {len(result)} plugged in')
+        sys.exit(1)
+
+    return result[0]
+
+if args['current']:
+    info = get_display_info()
+    print(f"Display Name:       {info['name']}")
+    print(f"Display Resolution: {info['resolution']}")
+elif args['list']:
+    print('okay')
+else:
+    print('oh no')
+

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -170,6 +170,23 @@ elif args['set_1080p']:
     if new_info['resolution'] != desired_resolution:
         print("Warning: Issued xrandr request, but the resolution doesn't seem to have change")
     save_display_info(old_info)
+elif args['revert']:
+    prev_info = load_display_info()
+    curr_info = get_display_info()
+    if prev_info['name'] != curr_info['name']:
+        print(f"Error: display has changed, prev={prev_info['name']}, curr={curr_info['name']}")
+        sys.exit(1)
+
+    desired_resolution = prev_info['resolution']
+    if desired_resolution not in curr_info['available_resolutions']:
+        print(f'Error: previous resolution, {desired_resolution}, not available')
+        sys.exit(1)
+    issue_xrandr_command(curr_info['name'], desired_resolution)
+
+    new_info = get_display_info()
+    if new_info['resolution'] != desired_resolution:
+        print("Warning: Issued xrandr request, but the resolution doesn't seem to have change")
+    clear_display_info()
 else:
     parser.print_help()
 

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -87,6 +87,7 @@ def get_display_info():
 
 def save_display_info(info):
     f = pathlib.Path(hu.get_stretch_directory()) / 'log' / 'previous_display_resolution.yaml'
+    f.parent.mkdir(exist_ok=True, parents=True)
     if f.is_file():
         print('Warning: previous display resolution already saved. Not overwriting.')
         return

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -5,6 +5,8 @@ hu.print_stretch_re_use()
 
 import os
 import sys
+import yaml
+import pathlib
 import argparse
 from Xlib import display
 from Xlib.ext import randr
@@ -83,6 +85,31 @@ def get_display_info():
 
     return oresult
 
+def save_display_info(info):
+    f = pathlib.Path(hu.get_stretch_directory()) / 'log' / 'previous_display_resolution.yaml'
+    if f.is_file():
+        print('Warning: previous display resolution already saved. Not overwriting.')
+        return
+    with open(str(f), 'w') as s:
+        yaml.dump(info, s)
+
+def load_display_info():
+    f = pathlib.Path(hu.get_stretch_directory()) / 'log' / 'previous_display_resolution.yaml'
+    if not f.is_file():
+        print('Error: cannot find previous display resolution')
+        sys.exit(1)
+    with open(str(f), 'r') as s:
+        try:
+            info = yaml.safe_load(s)
+        except:
+            print('Error: unable to load previous display resolution')
+            sys.exit(1)
+    return info
+
+def clear_display_info():
+    f = pathlib.Path(hu.get_stretch_directory()) / 'log' / 'previous_display_resolution.yaml'
+    f.unlink(missing_ok=True)
+
 if args['current']:
     info = get_display_info()
     print(f"Display Name:       {info['name']}")
@@ -116,7 +143,7 @@ elif args['set']:
     new_info = get_display_info()
     if new_info['resolution'] != desired_resolution:
         print("Warning: Issued xrandr request, but the resolution doesn't seem to have change")
-    # print(new_info, old_info)
+    save_display_info(info)
 else:
     parser.print_help()
 

--- a/python/tools/REx_xrandr_display.py
+++ b/python/tools/REx_xrandr_display.py
@@ -23,7 +23,7 @@ args = vars(parser.parse_args())
 def find_mode(id, modes):
     for mode in modes:
         if id == mode.id:
-            return f"{mode.width}x{mode.height}x{mode.dot_clock / (mode.h_total * mode.v_total)}"
+            return f"{mode.width}x{mode.height}x{mode.dot_clock / (mode.h_total * mode.v_total):.2f}"
 
 def get_display_info():
     try:


### PR DESCRIPTION
This PR introduces `REx_xrandr_display.py`, a tool to assist with changing the display's resolution programmatically.

```
$ REx_xrandr_display.py --current
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

Display Name:       HDMI-1
Display Resolution: 1920x1080x60.00
$ REx_xrandr_display.py --set-720p
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

$ REx_xrandr_display.py --current
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

Display Name:       HDMI-1
Display Resolution: 1280x720x60.00
$ REx_xrandr_display.py --revert
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

$ REx_xrandr_display.py --current
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

Display Name:       HDMI-1
Display Resolution: 1920x1080x60.00
$ REx_xrandr_display.py --revert
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

Error: cannot find previous display resolution
$ REx_xrandr_display.py --list
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

Available Resolutions:
640x480x59.94
640x480x60.00
640x480x75.00
640x480x72.81
720x576x50.00
720x480x60.00
720x480x59.94
800x600x56.25
800x600x72.19
800x600x60.32
800x600x75.00
1024x768x60.00
1024x768x75.03
1024x768x70.07
1280x720x60.00
1280x800x59.91
1280x1024x75.02
1280x720x59.94
1280x720x50.00
1440x900x59.90
1600x900x60.00
1680x1050x59.88
1920x1080x119.88
1920x1080x120.00
1920x1080x60.00
1920x1200x59.95
1920x1080x50.00
1920x1080x23.98
1920x1080x24.00
2560x1600x59.97
2560x1440x59.95
2880x1800x60.00
3840x2160x29.97
3840x2160x30.00
3840x2160x23.98
3840x2160x25.00
3840x2160x24.00
4096x2160x23.98
4096x2160x24.00
$ REx_xrandr_display.py --set 1600x900x60.00
For use with S T R E T C H (R) from Hello Robot Inc.
---------------------------------------------------------------------

```

This tool will be used by the Moonlight Remote Desktop software to enable users to run untethered navigation and demos with Stretch.